### PR TITLE
fixed how process metrics are deduped

### DIFF
--- a/collector/process.go
+++ b/collector/process.go
@@ -44,13 +44,13 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 			return
 		}
 
-		m := make(map[string]process)
+		m := make(map[string]*process)
 		for _, proc := range procs {
 			if value, ok := m[proc.Comm]; ok {
 				value.totalCPUTime += proc.CPUTime
 				value.totalMemory += float64(proc.ResidentMemory)
 			} else {
-				m[proc.Comm] = process{
+				m[proc.Comm] = &process{
 					totalCPUTime: proc.CPUTime,
 					totalMemory:  float64(proc.ResidentMemory),
 				}

--- a/collector/process_test.go
+++ b/collector/process_test.go
@@ -45,6 +45,14 @@ func TestRegisterProcessMetrics(t *testing.T) {
 			Comm:           "foo",
 			CmdLine:        []string{"a", "b"},
 		},
+		procfs.ProcProc{
+			PID:            int(2),
+			CPUTime:        float64(3),
+			ResidentMemory: int(2),
+			VirtualMemory:  int(1),
+			Comm:           "foo",
+			CmdLine:        []string{"a", "b"},
+		},
 	}
 
 	expectedNames := []string{
@@ -66,5 +74,13 @@ func TestRegisterProcessMetrics(t *testing.T) {
 
 	if r.AddCollectorFunc == nil {
 		t.Error("expected collector function, found none")
+	}
+
+	if len(s.UpdateSet) != 2 {
+		t.Fatalf("wrong number of updates were called")
+	}
+
+	if s.UpdateSet[0].Value != 5 {
+		t.Fatalf("multiple processes were not added together")
 	}
 }


### PR DESCRIPTION
Updating maps of values doesn't update the value stored in the map: https://play.golang.org/p/GRN-C7vaaH

Changing to using a map of pointers ensures that the values are correctly updated