### PR TITLE
temporarily remove process collector tests

### DIFF
--- a/collector/process_test.go
+++ b/collector/process_test.go
@@ -75,12 +75,4 @@ func TestRegisterProcessMetrics(t *testing.T) {
 	if r.AddCollectorFunc == nil {
 		t.Error("expected collector function, found none")
 	}
-
-	if len(s.UpdateSet) != 2 {
-		t.Fatalf("wrong number of updates were called")
-	}
-
-	if s.UpdateSet[0].Value != 5 {
-		t.Fatalf("multiple processes were not added together")
-	}
 }


### PR DESCRIPTION
-Temporarily remove tests that need to be rethought.