### PR TITLE
Use `apt-get purge` to avoid reinstallation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ yum install do-agent
 
 ### Apt
 
-`sudo apt-get remove do-agent`
+`sudo apt-get purge do-agent`
 
 
 ## Package installation


### PR DESCRIPTION
Fixes `chown: invalid group: ‘nobody:nobody’` on reinstallation.

cc @cagedmantis @imchairmanm 