### PR TITLE
Fix a bug where the netdev metrics would be ignored.

### DIFF
--- a/procfs/netdev.go
+++ b/procfs/netdev.go
@@ -91,30 +91,33 @@ func readNetwork(f io.Reader) ([]Network, error) {
 // parseNetwork parses a string and returns a Network if the string is
 // in the expected format.
 func parseNetwork(line string) (Network, error) {
-	lineArray := strings.Fields(line)
+	fields := strings.FieldsFunc(line, func(c rune) bool {
+		cStr := string(c)
+		return cStr == " " || cStr == ":"
+	})
 
-	if len(lineArray) != 17 {
+	if len(fields) != 17 {
 		return Network{}, errors.New("Field mismatch error while parsing: " + networkPath)
 	}
 
 	network := Network{}
-	network.Interface = strings.TrimRight(lineArray[0], ":")
-	network.RXBytes, _ = strconv.ParseUint(lineArray[1], 10, 64)
-	network.RXPackets, _ = strconv.ParseUint(lineArray[2], 10, 64)
-	network.RXErrs, _ = strconv.ParseUint(lineArray[3], 10, 64)
-	network.RXDrop, _ = strconv.ParseUint(lineArray[4], 10, 64)
-	network.RXFifo, _ = strconv.ParseUint(lineArray[5], 10, 64)
-	network.RXFrame, _ = strconv.ParseUint(lineArray[6], 10, 64)
-	network.RXCompressed, _ = strconv.ParseUint(lineArray[7], 10, 64)
-	network.RXMulticast, _ = strconv.ParseUint(lineArray[8], 10, 64)
-	network.TXBytes, _ = strconv.ParseUint(lineArray[9], 10, 64)
-	network.TXPackets, _ = strconv.ParseUint(lineArray[10], 10, 64)
-	network.TXErrs, _ = strconv.ParseUint(lineArray[11], 10, 64)
-	network.TXDrop, _ = strconv.ParseUint(lineArray[12], 10, 64)
-	network.TXFifo, _ = strconv.ParseUint(lineArray[13], 10, 64)
-	network.TXColls, _ = strconv.ParseUint(lineArray[14], 10, 64)
-	network.TXCarrier, _ = strconv.ParseUint(lineArray[15], 10, 64)
-	network.TXCompressed, _ = strconv.ParseUint(lineArray[16], 10, 64)
+	network.Interface = fields[0]
+	network.RXBytes, _ = strconv.ParseUint(fields[1], 10, 64)
+	network.RXPackets, _ = strconv.ParseUint(fields[2], 10, 64)
+	network.RXErrs, _ = strconv.ParseUint(fields[3], 10, 64)
+	network.RXDrop, _ = strconv.ParseUint(fields[4], 10, 64)
+	network.RXFifo, _ = strconv.ParseUint(fields[5], 10, 64)
+	network.RXFrame, _ = strconv.ParseUint(fields[6], 10, 64)
+	network.RXCompressed, _ = strconv.ParseUint(fields[7], 10, 64)
+	network.RXMulticast, _ = strconv.ParseUint(fields[8], 10, 64)
+	network.TXBytes, _ = strconv.ParseUint(fields[9], 10, 64)
+	network.TXPackets, _ = strconv.ParseUint(fields[10], 10, 64)
+	network.TXErrs, _ = strconv.ParseUint(fields[11], 10, 64)
+	network.TXDrop, _ = strconv.ParseUint(fields[12], 10, 64)
+	network.TXFifo, _ = strconv.ParseUint(fields[13], 10, 64)
+	network.TXColls, _ = strconv.ParseUint(fields[14], 10, 64)
+	network.TXCarrier, _ = strconv.ParseUint(fields[15], 10, 64)
+	network.TXCompressed, _ = strconv.ParseUint(fields[16], 10, 64)
 
 	return network, nil
 }

--- a/procfs/netdev_test.go
+++ b/procfs/netdev_test.go
@@ -27,60 +27,120 @@ const testNetworkValues = `Inter-|   Receive                                    
   eth0:  258319    2330    0    0    0     0          0         0   186144    1875    0    0    0     0       0          0
 `
 
+const testNetworkValuesModSpace = `Inter-| Receive | Transmit 
+face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed 
+lo: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
+eth0:2345774233 3330352 0 0 0 0 0 0 1345496555 2356444 0 0 0 2 0 0
+`
+
 func TestNewNetwork(t *testing.T) {
-	n, err := readNetwork(strings.NewReader(testNetworkValues))
-	if err != nil {
-		t.Errorf("Unable to read test values")
+	testCases := []struct {
+		label   string
+		values  string
+		wantLen int
+	}{
+		{"baseline", testNetworkValues, 2},
+		{"modSpacing", testNetworkValuesModSpace, 2},
 	}
 
-	expectedLen := 2
-	if len(n) != expectedLen {
-		t.Errorf("Expected %d network items, actual was %d", expectedLen, len(n))
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			n, err := readNetwork(strings.NewReader(tc.values))
+			if err != nil {
+				t.Fatal("unable to read test values")
+			}
+
+			if tc.wantLen != len(n) {
+				t.Errorf("got %d; want %d", len(n), tc.wantLen)
+			}
+		})
 	}
 }
 
 func TestParseNetworkValues(t *testing.T) {
-	const testLine = "    lo:       107       1    2    3    4     5          6         7        8       89    9    10    11     12       13          33"
+	const line = "    lo:       107       1    2    3    4     5          6         7        8       89    9    10    11     12       13          33"
+	const lineModSpace = "eth0:1247774233 1260352 0 0 0 0 0 0 1345496819 2356759 0 0 0 0 0 0"
 
-	net, err := parseNetwork(testLine)
-	if err != nil {
-		t.Errorf("Unexpected error occured while parsing \"%s\" error=%s", testLine, err)
-	}
-
-	netr := reflect.ValueOf(net)
-
-	var netTestValues = []struct {
+	type testCase struct {
 		n        string
 		expected uint64
+	}
+
+	testCases := []struct {
+		label  string
+		line   string
+		netInt string
+		values []testCase
 	}{
-		{"RXBytes", 107},
-		{"RXPackets", 1},
-		{"RXErrs", 2},
-		{"RXDrop", 3},
-		{"RXFifo", 4},
-		{"RXFrame", 5},
-		{"RXCompressed", 6},
-		{"RXMulticast", 7},
-		{"TXBytes", 8},
-		{"TXPackets", 89},
-		{"TXErrs", 9},
-		{"TXDrop", 10},
-		{"TXFifo", 11},
-		{"TXColls", 12},
-		{"TXCarrier", 13},
-		{"TXCompressed", 33},
+		{
+			"baseline",
+			line,
+			"lo",
+			[]testCase{
+				{"RXBytes", 107},
+				{"RXPackets", 1},
+				{"RXErrs", 2},
+				{"RXDrop", 3},
+				{"RXFifo", 4},
+				{"RXFrame", 5},
+				{"RXCompressed", 6},
+				{"RXMulticast", 7},
+				{"TXBytes", 8},
+				{"TXPackets", 89},
+				{"TXErrs", 9},
+				{"TXDrop", 10},
+				{"TXFifo", 11},
+				{"TXColls", 12},
+				{"TXCarrier", 13},
+				{"TXCompressed", 33},
+			},
+		},
+		{
+			"baseline",
+			lineModSpace,
+			"eth0",
+			[]testCase{
+				{"RXBytes", 1247774233},
+				{"RXPackets", 1260352},
+				{"RXErrs", 0},
+				{"RXDrop", 0},
+				{"RXFifo", 0},
+				{"RXFrame", 0},
+				{"RXCompressed", 0},
+				{"RXMulticast", 0},
+				{"TXBytes", 1345496819},
+				{"TXPackets", 2356759},
+				{"TXErrs", 0},
+				{"TXDrop", 0},
+				{"TXFifo", 0},
+				{"TXColls", 0},
+				{"TXCarrier", 0},
+				{"TXCompressed", 0},
+			},
+		},
 	}
 
-	for _, nt := range netTestValues {
-		actual := reflect.Indirect(netr).FieldByName(nt.n).Uint()
-		if actual != nt.expected {
-			t.Errorf("Network.%s: expected %d, actual %d", nt.n, nt.expected, actual)
-		}
-	}
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
 
-	expectedInterface := "lo"
-	if net.Interface != expectedInterface {
-		t.Errorf("Network.Interface: expected %s, actual %s", expectedInterface, net.Interface)
+			net, err := parseNetwork(tc.line)
+			if err != nil {
+				t.Fatal("Unable to parse")
+			}
+
+			netr := reflect.ValueOf(net)
+
+			for _, nt := range tc.values {
+				actual := reflect.Indirect(netr).FieldByName(nt.n).Uint()
+				if actual != nt.expected {
+					t.Errorf("want %d; got %d", nt.expected, actual)
+				}
+			}
+
+			if net.Interface != tc.netInt {
+				t.Errorf("want %s; got %s", tc.netInt, net.Interface)
+			}
+		})
 	}
 }
 
@@ -89,6 +149,6 @@ func TestParseNetworkFail(t *testing.T) {
 
 	_, err := parseNetwork(testFailLine)
 	if err == nil {
-		t.Errorf("Expected error did not occur while parsing \"%s\", there aren't enough fields", testFailLine)
+		t.Error("expected error did not occur")
 	}
 }


### PR DESCRIPTION
While parsing network metrics found in /proc/netdev, interfaces would be ignored if there wasn't a space between the interface + colon and the received bytes.