### PR TITLE
Only check for new agent updates once per day

### DIFF
--- a/cmd/do-agent/main.go
+++ b/cmd/do-agent/main.go
@@ -153,7 +153,7 @@ func main() {
 		log.Debug(fmt.Sprintf("sleeping for %d seconds", pushInterval))
 		time.Sleep(time.Duration(pushInterval) * time.Second)
 
-		if time.Now().After(lastUpdate.Add(1 * time.Hour)) {
+		if time.Now().After(lastUpdate.Add(24 * time.Hour)) {
 			lastUpdate = time.Now()
 			updateAgentWithRestart(updater)
 		}


### PR DESCRIPTION
I see this in my /var/log/syslog every hour:

> Checking for newer version of do-agent

It seems excessive since Ubuntu only checks for security updates once per day.

Because it does not update the apt cache (which is already done by Ubuntu's unattended-upgrades once per day), of course it will only work at most once per day (at least on Ubuntu).