### PR TITLE
Calculate CPU usage per process (and children)

### DIFF
--- a/collector/process.go
+++ b/collector/process.go
@@ -24,8 +24,13 @@ import (
 const processSystem = "process"
 
 type process struct {
-	totalCPUTime float64
-	totalMemory  float64
+	totalCPUTime       float64
+	userCPUTime        float64
+	kernelCPUTime      float64
+	childUserCPUTime   float64
+	childKernelCPUTime float64
+	startTimeCPUTime   float64
+	totalMemory        float64
 }
 
 type procprocFunc func() ([]procfs.ProcProc, error)
@@ -35,6 +40,17 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 	memory := r.Register(processSystem+"_memory",
 		metrics.WithMeasuredLabels("process"))
 	cpu := r.Register(processSystem+"_cpu",
+		metrics.WithMeasuredLabels("process"))
+
+	ucpu := r.Register(processSystem+"_cpu_user",
+		metrics.WithMeasuredLabels("process"))
+	scpu := r.Register(processSystem+"_cpu_kernel",
+		metrics.WithMeasuredLabels("process"))
+	cucpu := r.Register(processSystem+"_cpu_child_user",
+		metrics.WithMeasuredLabels("process"))
+	cscpu := r.Register(processSystem+"_cpu_child_kernel",
+		metrics.WithMeasuredLabels("process"))
+	startcpu := r.Register(processSystem+"_cpu_start",
 		metrics.WithMeasuredLabels("process"))
 
 	r.AddCollector(func(r metrics.Reporter) {
@@ -48,11 +64,21 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 		for _, proc := range procs {
 			if value, ok := m[proc.Comm]; ok {
 				value.totalCPUTime += proc.CPUTime
+				value.userCPUTime += proc.UserCPUTime
+				value.kernelCPUTime += proc.KernelCPUTime
+				value.childUserCPUTime += proc.ChildUserCPUTime
+				value.childKernelCPUTime += proc.ChildKernelCPUTime
 				value.totalMemory += float64(proc.ResidentMemory)
 			} else {
 				m[proc.Comm] = &process{
 					totalCPUTime: proc.CPUTime,
 					totalMemory:  float64(proc.ResidentMemory),
+
+					userCPUTime:        proc.UserCPUTime,
+					kernelCPUTime:      proc.KernelCPUTime,
+					childUserCPUTime:   proc.ChildUserCPUTime,
+					childKernelCPUTime: proc.ChildKernelCPUTime,
+					startTimeCPUTime:   proc.StartTimeCPUTime,
 				}
 			}
 		}
@@ -60,6 +86,12 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 		for key, value := range m {
 			r.Update(memory, value.totalMemory, key)
 			r.Update(cpu, value.totalCPUTime, key)
+
+			r.Update(ucpu, value.userCPUTime, key)
+			r.Update(scpu, value.kernelCPUTime, key)
+			r.Update(cucpu, value.childUserCPUTime, key)
+			r.Update(cscpu, value.childKernelCPUTime, key)
+			r.Update(startcpu, value.startTimeCPUTime, key)
 		}
 	})
 }

--- a/collector/process.go
+++ b/collector/process.go
@@ -24,13 +24,8 @@ import (
 const processSystem = "process"
 
 type process struct {
-	totalCPUTime       float64
-	userCPUTime        float64
-	kernelCPUTime      float64
-	childUserCPUTime   float64
-	childKernelCPUTime float64
-	startTimeCPUTime   float64
-	totalMemory        float64
+	totalCPUUsage float64
+	totalMemory   float64
 }
 
 type procprocFunc func() ([]procfs.ProcProc, error)
@@ -40,17 +35,6 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 	memory := r.Register(processSystem+"_memory",
 		metrics.WithMeasuredLabels("process"))
 	cpu := r.Register(processSystem+"_cpu",
-		metrics.WithMeasuredLabels("process"))
-
-	ucpu := r.Register(processSystem+"_cpu_user",
-		metrics.WithMeasuredLabels("process"))
-	scpu := r.Register(processSystem+"_cpu_kernel",
-		metrics.WithMeasuredLabels("process"))
-	cucpu := r.Register(processSystem+"_cpu_child_user",
-		metrics.WithMeasuredLabels("process"))
-	cscpu := r.Register(processSystem+"_cpu_child_kernel",
-		metrics.WithMeasuredLabels("process"))
-	startcpu := r.Register(processSystem+"_cpu_start",
 		metrics.WithMeasuredLabels("process"))
 
 	r.AddCollector(func(r metrics.Reporter) {
@@ -63,35 +47,19 @@ func RegisterProcessMetrics(r metrics.Registry, fn procprocFunc) {
 		m := make(map[string]*process)
 		for _, proc := range procs {
 			if value, ok := m[proc.Comm]; ok {
-				value.totalCPUTime += proc.CPUTime
-				value.userCPUTime += proc.UserCPUTime
-				value.kernelCPUTime += proc.KernelCPUTime
-				value.childUserCPUTime += proc.ChildUserCPUTime
-				value.childKernelCPUTime += proc.ChildKernelCPUTime
+				value.totalCPUUsage = proc.CPUUsage
 				value.totalMemory += float64(proc.ResidentMemory)
 			} else {
 				m[proc.Comm] = &process{
-					totalCPUTime: proc.CPUTime,
-					totalMemory:  float64(proc.ResidentMemory),
-
-					userCPUTime:        proc.UserCPUTime,
-					kernelCPUTime:      proc.KernelCPUTime,
-					childUserCPUTime:   proc.ChildUserCPUTime,
-					childKernelCPUTime: proc.ChildKernelCPUTime,
-					startTimeCPUTime:   proc.StartTimeCPUTime,
+					totalCPUUsage: proc.CPUUsage,
+					totalMemory:   float64(proc.ResidentMemory),
 				}
 			}
 		}
 
 		for key, value := range m {
 			r.Update(memory, value.totalMemory, key)
-			r.Update(cpu, value.totalCPUTime, key)
-
-			r.Update(ucpu, value.userCPUTime, key)
-			r.Update(scpu, value.kernelCPUTime, key)
-			r.Update(cucpu, value.childUserCPUTime, key)
-			r.Update(cscpu, value.childKernelCPUTime, key)
-			r.Update(startcpu, value.startTimeCPUTime, key)
+			r.Update(cpu, value.totalCPUUsage, key)
 		}
 	})
 }

--- a/collector/process_test.go
+++ b/collector/process_test.go
@@ -39,7 +39,7 @@ func TestRegisterProcessMetrics(t *testing.T) {
 	p.NewProcProcResultProcProcs = []procfs.ProcProc{
 		procfs.ProcProc{
 			PID:            int(1),
-			CPUTime:        float64(2),
+			CPUUsage:       float64(2),
 			ResidentMemory: int(3),
 			VirtualMemory:  int(4),
 			Comm:           "foo",
@@ -47,7 +47,7 @@ func TestRegisterProcessMetrics(t *testing.T) {
 		},
 		procfs.ProcProc{
 			PID:            int(2),
-			CPUTime:        float64(3),
+			CPUUsage:       float64(3),
 			ResidentMemory: int(2),
 			VirtualMemory:  int(1),
 			Comm:           "foo",

--- a/procfs/main/main.go
+++ b/procfs/main/main.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+import "github.com/digitalocean/do-agent/procfs"
+
+func main() {
+	allProcs, err := procfs.NewProcProc()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("PID,Command,BootTime,StartTime,CPUUsage")
+	for _, p := range allProcs {
+		fmt.Printf("%d,%s,%.2f,%.2f,%.2f\n", p.PID, p.Comm, p.BootTime, p.StartTime, p.CPUUsage)
+	}
+}

--- a/procfs/main/main.go
+++ b/procfs/main/main.go
@@ -1,16 +1,46 @@
 package main
 
-import "fmt"
-import "github.com/digitalocean/do-agent/procfs"
+import (
+	"fmt"
+	"time"
+
+	"github.com/digitalocean/do-agent/procfs"
+)
 
 func main() {
-	allProcs, err := procfs.NewProcProc()
-	if err != nil {
-		panic(err)
+	processes := map[int]uint64{}
+	previousTotalTime := totalCPUTime()
+	allProcs, _ := procfs.NewProcProc()
+	for _, p := range allProcs {
+		processes[p.PID] = uint64(p.UTime + p.STime)
 	}
 
-	fmt.Println("PID,Command,BootTime,StartTime,CPUUsage")
-	for _, p := range allProcs {
-		fmt.Printf("%d,%s,%.2f,%.2f,%.2f\n", p.PID, p.Comm, p.BootTime, p.StartTime, p.CPUUsage)
+	fmt.Println("PID,Command,Utilization")
+	for {
+		time.Sleep(1 * time.Second)
+
+		totalTime := totalCPUTime()
+		fmt.Println(totalTime)
+		allProcs, _ := procfs.NewProcProc()
+		for _, p := range allProcs {
+			t := uint64(p.UTime + p.STime)
+			utilization := 100 * (t - processes[p.PID]) / (totalTime - previousTotalTime)
+			fmt.Printf("%5d %15s %5d%% %d\n", p.PID, p.Comm, utilization, t)
+			processes[p.PID] = t
+		}
+		previousTotalTime = totalTime
 	}
+}
+
+func totalCPUTime() uint64 {
+	var cpu procfs.CPU
+
+	s, _ := procfs.NewStat()
+	for _, c := range s.CPUS {
+		if c.CPU == "cpu" {
+			cpu = c
+		}
+	}
+
+	return cpu.TotalTime()
 }

--- a/procfs/main/main.go
+++ b/procfs/main/main.go
@@ -10,32 +10,41 @@ import (
 func main() {
 	processes := map[int]uint64{}
 	previousTotalTime := totalCPUTime()
-	allProcs, _ := procfs.NewProcProc()
+	allProcs, err := procfs.NewProcProc()
+	if err != nil {
+		panic(err)
+	}
 	for _, p := range allProcs {
 		processes[p.PID] = uint64(p.UTime + p.STime)
 	}
 
-	fmt.Println("PID,Command,Utilization")
+	fmt.Printf("%-5s %-10s %6s %6s\n", "PID", "Command", "CPU %", "Time")
 	for {
-		time.Sleep(1 * time.Second)
-
 		totalTime := totalCPUTime()
-		fmt.Println(totalTime)
-		allProcs, _ := procfs.NewProcProc()
+		allProcs, err := procfs.NewProcProc()
+		if err != nil {
+			panic(err)
+		}
+
 		for _, p := range allProcs {
 			t := uint64(p.UTime + p.STime)
 			utilization := 100 * (t - processes[p.PID]) / (totalTime - previousTotalTime)
-			fmt.Printf("%5d %15s %5d%% %d\n", p.PID, p.Comm, utilization, t)
+			fmt.Printf("%5d %-10s %5d%% %6d\n", p.PID, p.Comm, utilization, t)
 			processes[p.PID] = t
 		}
 		previousTotalTime = totalTime
+		time.Sleep(1 * time.Second)
 	}
 }
 
 func totalCPUTime() uint64 {
 	var cpu procfs.CPU
 
-	s, _ := procfs.NewStat()
+	s, err := procfs.NewStat()
+	if err != nil {
+		panic(err)
+	}
+
 	for _, c := range s.CPUS {
 		if c.CPU == "cpu" {
 			cpu = c

--- a/procfs/main/sine.py
+++ b/procfs/main/sine.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import itertools, math, time, sys
+
+time_period = float(sys.argv[1]) if len(sys.argv) > 1 else 30   # seconds
+time_slice  = float(sys.argv[2]) if len(sys.argv) > 2 else 0.04 # seconds
+
+N = int(time_period / time_slice)
+for i in itertools.cycle(range(N)):
+    busy_time = time_slice / 2 * (math.sin(2*math.pi*i/N) + 1)
+    t = time.clock() + busy_time
+    while t > time.clock():
+        pass
+    time.sleep(time_slice - busy_time)

--- a/procfs/proc.go
+++ b/procfs/proc.go
@@ -31,6 +31,10 @@ type ProcProc struct {
 	CmdLine        []string
 	StartTime      float64
 	BootTime       float64
+	UTime          uint
+	STime          uint
+	CUTime         uint
+	CSTime         uint
 }
 
 // Procer is a collection of process metrics exposed by the
@@ -76,6 +80,11 @@ func NewProcProc() ([]ProcProc, error) {
 		x, err := procfs.NewFS(procfs.DefaultMountPoint)
 		y, err := x.NewStat()
 		p.BootTime = float64(y.BootTime)
+
+		p.UTime = stat.UTime
+		p.STime = stat.STime
+		p.CUTime = stat.CUTime
+		p.CSTime = stat.CSTime
 
 		// As described in http://stackoverflow.com/a/16736599/16944
 		ticks := float64(stat.UTime + stat.STime + stat.CUTime + stat.CSTime)

--- a/procfs/proc.go
+++ b/procfs/proc.go
@@ -26,6 +26,12 @@ type ProcProc struct {
 	VirtualMemory  int     //value in bytes
 	Comm           string
 	CmdLine        []string
+
+	UserCPUTime        float64
+	KernelCPUTime      float64
+	ChildUserCPUTime   float64
+	ChildKernelCPUTime float64
+	StartTimeCPUTime   float64
 }
 
 // Procer is a collection of process metrics exposed by the
@@ -62,6 +68,12 @@ func NewProcProc() ([]ProcProc, error) {
 		if err != nil {
 			continue // because the rest of the values can't be queried
 		}
+
+		p.UserCPUTime = float64(stat.UTime)
+		p.KernelCPUTime = float64(stat.STime)
+		p.ChildUserCPUTime = float64(stat.CUTime)
+		p.ChildKernelCPUTime = float64(stat.CSTime)
+		p.StartTimeCPUTime, _ = stat.StartTime()
 
 		p.VirtualMemory = stat.VirtualMemory()
 		p.ResidentMemory = stat.ResidentMemory()

--- a/procfs/proc.go
+++ b/procfs/proc.go
@@ -29,6 +29,8 @@ type ProcProc struct {
 	VirtualMemory  int     //value in bytes
 	Comm           string
 	CmdLine        []string
+	StartTime      float64
+	BootTime       float64
 }
 
 // Procer is a collection of process metrics exposed by the
@@ -69,14 +71,15 @@ func NewProcProc() ([]ProcProc, error) {
 		p.VirtualMemory = stat.VirtualMemory()
 		p.ResidentMemory = stat.ResidentMemory()
 
-		startTime, err := stat.StartTime()
-		if err != nil {
-			continue // because the rest of the values can't be queried
-		}
+		p.StartTime = float64(stat.Starttime)
+
+		x, err := procfs.NewFS(procfs.DefaultMountPoint)
+		y, err := x.NewStat()
+		p.BootTime = float64(y.BootTime)
 
 		// As described in http://stackoverflow.com/a/16736599/16944
 		ticks := float64(stat.UTime + stat.STime + stat.CUTime + stat.CSTime)
-		p.CPUUsage = float64(100 * ((ticks / userHZ) / startTime))
+		p.CPUUsage = float64(100 * ((ticks / userHZ) / p.StartTime))
 
 		ps = append(ps, p)
 	}

--- a/procfs/stat.go
+++ b/procfs/stat.go
@@ -72,6 +72,11 @@ func NewStat() (Stat, error) {
 	return readStat(f)
 }
 
+// TotalTime (in jiffies) executed by this CPU
+func (c CPU) TotalTime() uint64 {
+	return c.User + c.Nice + c.System + c.Idle + c.Iowait + c.Irq + c.Softirq + c.Steal + c.Guest + c.GuestNice
+}
+
 func readStat(f io.Reader) (Stat, error) {
 	var stat Stat
 


### PR DESCRIPTION
This stops the agent from reporting CPU time (or each individual user, system, child user and child system times) and calculates the % of CPU usage per process (and its children) based on process start time and machine uptime.

Maths lifted from [this StackOverflow answer](http://stackoverflow.com/a/16736599/16944).