### PR TITLE
Replace currentExecPath() with osext.Executable() for portability

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/do-agent/config"
+	"github.com/kardianos/osext"
 
 	"github.com/flynn/go-tuf/client"
 	tufdata "github.com/flynn/go-tuf/data"
@@ -129,7 +130,7 @@ func (u *update) findUpdates(forceUpdate bool) (string, error) {
 // the running binary and calls exec on the new binary.
 func (u *update) FetchLatestAndExec(forceUpdate bool) error {
 	// record bin path before update
-	binPathOrig, err := currentExecPath()
+	binPathOrig, err := osext.Executable()
 	if err != nil {
 		return ErrUnableToDetermineRunningProcess{Reason: err.Error()}
 	}
@@ -145,7 +146,7 @@ func (u *update) FetchLatestAndExec(forceUpdate bool) error {
 		return err
 	}
 
-	binPath, err := currentExecPath()
+	binPath, err := osext.Executable()
 	if err != nil {
 		return ErrUnableToDetermineRunningProcess{Reason: err.Error()}
 	}
@@ -194,7 +195,7 @@ func (u *update) FetchLatest(forceUpdate bool) error {
 		return err
 	}
 
-	curFilePath, err := currentExecPath()
+	curFilePath, err := osext.Executable()
 	if err != nil {
 		return ErrUnableToDetermineRunningProcess{Reason: err.Error()}
 	}

--- a/update/util.go
+++ b/update/util.go
@@ -29,19 +29,6 @@ import (
 	tufdata "github.com/flynn/go-tuf/data"
 )
 
-const deletedTag = " (deleted)"
-
-// currentExecPath returns the path of the current running executable
-func currentExecPath() (string, error) {
-	path, err := os.Readlink("/proc/self/exe")
-	if err != nil {
-		return "", err
-	}
-	path = strings.TrimSuffix(path, deletedTag)
-	path = strings.TrimPrefix(path, deletedTag)
-	return path, nil
-}
-
 func parseKeys(rootKeyJSON string) ([]*tufdata.Key, error) {
 	var rootKeys []*tufdata.Key
 

--- a/update/util_test.go
+++ b/update/util_test.go
@@ -23,15 +23,6 @@ import (
 	"testing"
 )
 
-func TestCurrentExecPath(t *testing.T) {
-	if _, err := os.Stat("/proc/self/exe"); err != nil {
-		_, err2 := currentExecPath()
-		if err2 == nil {
-			t.Error("expected an error, got nil")
-		}
-	}
-}
-
 func TestParseKeys(t *testing.T) {
 	const (
 		key1 = ""

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -66,6 +66,12 @@
 			"revision": "0496a6c14df020789376f4d4a261273d5ddb36ec"
 		},
 		{
+			"checksumSHA1": "Mnp6EGM0pdGxMe19f6dg+ipjaSo=",
+			"path": "github.com/kardianos/osext",
+			"revision": "9b883c5eb462dd5cb1b0a7a104fe86bc6b9bd391",
+			"revisionTime": "2017-02-07T19:16:55Z"
+		},
+		{
 			"checksumSHA1": "kO2MAzPuortudABaRd7fY+7EaoM=",
 			"path": "github.com/prometheus/procfs",
 			"revision": "406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8"


### PR DESCRIPTION
This change fixes one of the early errors raised when trying to run the `do-agent` on non Linux platforms due to the updater execution.