### PR TITLE
filter refinement: filter on both file-systems and devices

### DIFF
--- a/collector/file_system.go
+++ b/collector/file_system.go
@@ -30,35 +30,55 @@ const (
 
 // excludedDevices are psudeo filesystems that are excluded from metrics.
 var excludedDevices = []string{
-	"autofs",
-	"binfmt_misc",
-	"cgroup",
-	"debugfs",
-	"devpts",
-	"efivarfs",
-	"fuse",
-	"hugetlbfs",
+	"fusectl",
 	"lxcfs",
 	"mqueue",
 	"none",
+	"rootfs",
+	"sunrpc",
+	"systemd",
+	"udev",
+}
+
+// excludedFSes are pseudo filesystems that are excluded from metrics
+var excludedFSes = []string{
+	"aufs",
+	"autofs",
+	"binfmt_misc",
+	"cifs",
+	"cgroup",
+	"debugfs",
+	"devpts",
+	"devtmpfs",
+	"ecryptfs",
+	"efivarfs",
+	"fuse",
+	"hugetlbfs",
+	"mqueue",
+	"nfs",
+	"overlayfs",
 	"proc",
 	"pstore",
-	"rootfs",
+	"rpc_pipefs",
 	"securityfs",
+	"smb",
 	"sysfs",
-	"systemd",
-	"tracefs",
 	"tmpfs",
-	"udev",
+	"tracefs",
 }
 
 type mountFunc func() ([]procfs.Mount, error)
 
 // isExlcuded checks if a filesystems matches the exlcudedDevice list. Regexp's were
 // considered but they can be slow.
-func isExcluded(c string) bool {
+func isExcluded(d, t string) bool {
 	for _, x := range excludedDevices {
-		if strings.Contains(c, x) {
+		if strings.Contains(d, x) {
+			return true
+		}
+	}
+	for _, y := range excludedFSes {
+		if strings.Contains(t, y) {
 			return true
 		}
 	}
@@ -82,8 +102,8 @@ func RegisterFSMetrics(r metrics.Registry, fn mountFunc, f Filters) {
 		}
 
 		for _, mount := range mounts {
-			if isExcluded(mount.Device) {
-				log.Debugf("Ignoring mount device : %s", mount.Device)
+			if isExcluded(mount.Device, mount.FSType) {
+				log.Debugf("Ignoring filesystem for device : %s %s ", mount.Device, mount.FSType)
 				continue
 			}
 

--- a/collector/filter.go
+++ b/collector/filter.go
@@ -29,7 +29,7 @@ type Filters struct {
 	Regexps    []*regexp.Regexp
 }
 
-// UpodateIfIncluded call r.Update if the metric should be included.
+// UpdateIfIncluded call r.Update if the metric should be included.
 func (f *Filters) UpdateIfIncluded(r metrics.Reporter, ref metrics.MetricRef, value float64, labelValues ...string) {
 	def, ok := ref.(*metrics.Definition)
 	if !ok {


### PR DESCRIPTION
- fixes an issue with double-reporting root that happens with Docker
- fixed comments

By filtering non-block psuedo filesystems, metric reporting dropped between 50-75% of the time. I want to clean this up dropping this in favor of a more dynamic check (i.e. look if the filesystem is backed by a block device?)