### PR TITLE
allow override of metadata url

### DIFF
--- a/monitoringclient/monitoringclient.go
+++ b/monitoringclient/monitoringclient.go
@@ -32,6 +32,9 @@ const (
 	// AuthURL is the address to the Sonar authentication server
 	AuthURL = "https://sonar.digitalocean.com"
 
+	// MetadataURL is the address to the metadata service
+	MetadataURL = "http://169.254.169.254"
+
 	userAgentHeader = "User-Agent"
 )
 


### PR DESCRIPTION
Here's an example of the metadata service being stubbed out for use in our tests:

doagent logs:

            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Do-Agent version dev
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Do-Agent build metadata-override.8748c5d
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Architecture: amd64
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Operating System: linux
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Metadata URL Override: http://metadatastub
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Authentication URL Override: http://radar:8081
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Metrics URL Override: http://wharf:8082
            doagent 2017-03-16T18:51:01 UNK 2017/03/16 18:51:01 Checking for newer version of do-agent

stubbed metadata service responding to metadata requests

       metadatastub 2017-03-16T18:50:57 UNK Started server at http://localhost:80.
       metadatastub 2017-03-16T18:51:01 INF request egid=0 eid=0 host=metadatastub pid=220 pname=/tmp/go-build176152046/command-line-arguments/_obj/exe/server url=/metadata/v1/auth-token version=
       metadatastub 2017-03-16T18:51:01 INF request egid=0 eid=0 host=metadatastub pid=220 pname=/tmp/go-build176152046/command-line-arguments/_obj/exe/server url=/metadata/v1/id version=
       metadatastub 2017-03-16T18:51:01 INF request egid=0 eid=0 host=metadatastub pid=220 pname=/tmp/go-build176152046/command-line-arguments/_obj/exe/server url=/metadata/v1/region version=


Example of agent running without metadata stubbed:

    root@ubuntu-2gb-nyc3-01:~# ./do-agent_linux_amd64 
    2017/03/16 18:54:56 Do-Agent version dev
    2017/03/16 18:54:56 Do-Agent build metadata-override.8748c5d
    2017/03/16 18:54:56 Architecture: amd64
    2017/03/16 18:54:56 Operating System: linux
    2017/03/16 18:54:56 Checking for newer version of do-agent


Example of agent running with a bad metadata config:

    root@ubuntu-2gb-nyc3-01:~# DO_AGENT_METADATA_URL=badurl ./do-agent_linux_amd64 
    2017/03/16 18:56:01 Do-Agent version dev
    2017/03/16 18:56:01 Do-Agent build metadata-override.8748c5d
    2017/03/16 18:56:01 Architecture: amd64
    2017/03/16 18:56:01 Operating System: linux
    2017/03/16 18:56:01 Metadata URL Override: badurl
    2017/03/16 18:56:01 Unable to read credentials: Get /metadata/v1/auth-token: unsupported       protocol scheme ""
    2017/03/16 18:56:01 do-agent requires a DigitalOcean host
