### PR TITLE
Allow customising interval or prevention of update checks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Contributors
 ------------
 Philip Baker      <pbaker@digitalocean.com>
 Bruno Tavares     <connect+github@bltavares.com>
+alzeih            <alzeih@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ DO_AGENT_METRICS_URL | string | Override metrics URL
 DO_AGENT_DROPLET_ID | int64 | Override Droplet ID
 DO_AGENT_AUTHTOKEN | string | Override AuthToken
 DO_AGENT_UPDATE_URL | string | Override Update URL
+DO_AGENT_UPDATE_INTERVAL | uint | Override Update Interval
 DO_AGENT_REPO_PATH | string | Override Local repository path
 DO_AGENT_PLUGIN_PATH | string | Override plugin directory path
 DO_AGENT_PROCFS_ROOT | string | Override location of /proc

--- a/update/update.go
+++ b/update/update.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/digitalocean/do-agent/config"
 
@@ -33,6 +34,9 @@ const (
 
 	// RepoURL is the remote TUF repository URL
 	RepoURL = "https://repos.sonar.digitalocean.com/tuf"
+
+	// Interval is the time in seconds between update checks
+	Interval = 3600
 
 	// RepoLocalStore is the local repository path
 	RepoLocalStore = "/var/opt/digitalocean/do-agent"
@@ -47,6 +51,7 @@ const (
 type Updater interface {
 	FetchLatestAndExec(bool) error
 	FetchLatest(bool) error
+	Interval() time.Duration
 }
 
 // Update manages the communication with the local repository, the
@@ -54,14 +59,16 @@ type Updater interface {
 type update struct {
 	localStorePath string
 	repositoryURL  string
+	interval       uint
 	client         *client.Client
 }
 
 // NewUpdate returns an Update object which has the components for a tuf client.
-func NewUpdate(localStorePath, repositoryURL string) Updater {
+func NewUpdate(localStorePath, repositoryURL string, interval uint) Updater {
 	return &update{
 		localStorePath: localStorePath,
 		repositoryURL:  repositoryURL,
+		interval:       interval,
 	}
 }
 
@@ -212,4 +219,9 @@ func (u *update) FetchLatest(forceUpdate bool) error {
 	}
 
 	return nil
+}
+
+// Interval returns the update interval
+func (u *update) Interval() time.Duration {
+	return time.Duration(u.interval) * time.Second
 }

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -16,11 +16,13 @@
 package update
 
 import "testing"
+import "time"
 
 func TestCreateTufClient(t *testing.T) {
 	u := &update{
 		localStorePath: "/tmp",
 		repositoryURL:  "not a url",
+		interval:       3600,
 		client:         nil,
 	}
 
@@ -32,6 +34,7 @@ func TestCreateTufClient(t *testing.T) {
 	u2 := &update{
 		localStorePath: "/tmp/aalllallalalallal",
 		repositoryURL:  "http://www.digitalocean.com",
+		interval:       3600,
 		client:         nil,
 	}
 
@@ -39,4 +42,31 @@ func TestCreateTufClient(t *testing.T) {
 	if err2 == nil {
 		t.Error("expected error, received nil")
 	}
+}
+
+func TestInterval(t *testing.T) {
+	u := &update{
+		localStorePath: "/tmp",
+		repositoryURL:  "not a url",
+		interval:       3600,
+		client:         nil,
+	}
+
+	interval1 := u.Interval()
+	if interval1 != time.Second*3600 {
+		t.Errorf("expected interval of 3600, received interval %s", interval1)
+	}
+
+	u2 := &update{
+		localStorePath: "/tmp",
+		repositoryURL:  "not a url",
+		interval:       0,
+		client:         nil,
+	}
+
+	interval2 := u2.Interval()
+	if interval2 != 0 {
+		t.Errorf("expected interval of 0, received %s", interval2)
+	}
+
 }


### PR DESCRIPTION
This could be useful when do-agent is packed by a distro and should not attempt to try to update itself automatically. 

It could also be useful to configure other versions to prevent auto updates (without mangling the updates URL) so manual updating can be performed on demand only (and without unmangling the URL).

It will prevent regular logging of update errors for packaged versions that can't be automatically upgraded if the environment variable is set.

It also allows for tuning of the interval which could be useful for debugging update functionality, or to check for updates on a different schedule of once a day/week/month.

* New environment variable DO_AGENT_UPDATE_INTERVAL
* Interval is now stored in seconds, default of 1 Hour
* DO_AGENT_UPDATE_INTERVAL=0 will prevent update checking
* Preventing updates doesn't effect `-force_update`