### PR TITLE
TS-1042

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ deb_package  := $(package_dir)/$(pkg_project)_$(version)_$(PKG_ARCH).deb
 rpm_package  := $(package_dir)/$(pkg_project)-$(version)-1.$(PKG_ARCH).rpm
 tar_package  := $(package_dir)/$(pkg_project)-$(version).tar.gz
 
-# use the binary's mtime for epoch for consistency
-epoch := $(shell date +%s -r $(binary))
+# use the binary's mtime for epoch for consistency. This needs to be lazily
+# evaluated since the binary does not yet exist
+epoch = $(shell date '+%s' -r $(binary))
 
 #############
 ## targets ##
@@ -126,6 +127,7 @@ $(base_package): $(binary)
 	$(print)
 	$(mkdir)
 	@$(fpm) --output-type deb \
+		--verbose \
 		--input-type dir \
 		--epoch $(epoch) \
 		--force \
@@ -151,6 +153,7 @@ $(deb_package): $(base_package)
 	$(print)
 	$(mkdir)
 	@$(fpm) --output-type deb \
+		--verbose \
 		--input-type deb \
 		--force \
 		--depends cron \
@@ -170,6 +173,7 @@ $(rpm_package): $(base_package)
 	$(print)
 	$(mkdir)
 	@$(fpm) \
+		--verbose \
 		--output-type rpm \
 		--input-type deb \
 		--depends cronie \
@@ -189,6 +193,7 @@ $(tar_package): $(base_package)
 	$(print)
 	$(mkdir)
 	@$(fpm) \
+		--verbose \
 		--output-type tar \
 		--input-type deb \
 		--force \


### PR DESCRIPTION
Fixing this issue in the rpm_package target:

```
:::::::::::::::: [Wed Dec  5 09:22:50 UTC 2018] target/pkg/do-agent-0.5.1-1.i386.rpm ::::::::::::::::Package version '-' includes dashes, converting to underscores {:level=>:warn}Process failed: rpmbuild failed (exit code 1). Full command was:["rpmbuild", "-bb", "--target", "i386", "--define", "buildroot /tmp/package-rpm-build-6f2344d0b0f3830f4fb41c3a180f05ce245ed88f5abecc424b646d8a55b4/BUILD", "--define", "_topdir /tmp/package-rpm-build-6f2344d0b0f3830f4fb41c3a180f05ce245ed88f5abecc424b646d8a55b4", "--define", "_sourcedir /tmp/package-rpm-build-6f2344d0b0f3830f4fb41c3a180f05ce245ed88f5abecc424b646d8a55b4", "--define", "_rpmdir /tmp/package-rpm-build-6f2344d0b0f3830f4fb41c3a180f05ce245ed88f5abecc424b646d8a55b4/RPMS", "--define", "_tmppath /tmp", "/tmp/package-rpm-build-6f2344d0b0f3830f4fb41c3a180f05ce245ed88f5abecc424b646d8a55b4/SPECS/do-agent.spec"] {:level=>:error} 
...
error: line 41: Illegal char ':' in: Release: force:0.5.1 {:level=>:info} 
```