### PR TITLE
move no-collector.processes flag to be consistent

### DIFF
--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/digitalocean/do-agent/internal/flags"
 	"github.com/digitalocean/do-agent/internal/log"
 	"github.com/digitalocean/do-agent/internal/process"
 	"github.com/digitalocean/do-agent/pkg/clients/tsclient"
@@ -32,6 +31,7 @@ var (
 		debug         bool
 		syslog        bool
 		kubernetes    bool
+		noProcesses   bool
 	}
 
 	// additionalParams is a list of extra command line flags to append
@@ -75,6 +75,9 @@ func init() {
 
 	kingpin.Flag("k8s", "enable DO Kubernetes metrics collection (this must be a DOK8s node)").
 		BoolVar(&config.kubernetes)
+
+	kingpin.Flag("no-collector.processes", "disable processes cpu/memory collection").Default("false").
+		BoolVar(&config.noProcesses)
 }
 
 func checkConfig() error {
@@ -148,7 +151,7 @@ func initCollectors() []prometheus.Collector {
 		buildInfo,
 	}
 
-	if !flags.NoProcessCollector {
+	if !config.noProcesses {
 		cols = append(cols, process.NewProcessCollector())
 	}
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -15,8 +15,6 @@ var (
 	SysfsPath = "/sys"
 	// RootfsPath is the configured path to the rootfs mountpoint
 	RootfsPath = "/"
-	// NoProcessCollector disables the Top Processes collector
-	NoProcessCollector = false
 )
 
 // Init initializes and reads system paths from command line flags
@@ -27,8 +25,6 @@ func Init(args []string) {
 	sysfsPath := app.Flag("path.sysfs", "sysfs mountpoint.").Default("/sys").String()
 	rootfsPath := app.Flag("path.rootfs", "rootfs mountpoint.").Default("/").String()
 
-	noProcesses := app.Flag("disable.processes", "disable top processes collection").Default("false").Bool()
-
 	_, err := app.Parse(args)
 	// this will always error for unknown flags passed in that aren't defined in
 	// this file since we only capture the flags we're interested in. this
@@ -38,5 +34,4 @@ func Init(args []string) {
 	ProcfsPath = *procfsPath
 	SysfsPath = *sysfsPath
 	RootfsPath = *rootfsPath
-	NoProcessCollector = *noProcesses
 }

--- a/scripts/uat.sh
+++ b/scripts/uat.sh
@@ -183,7 +183,9 @@ function exec_ips() {
 	ips=$1
 	shift
 	script="hostname -s; { $*; }"
-	echo "Dispatching..."
+	echo "================================================"
+	echo "> $*"
+	echo "================================================"
 	for ip in $ips; do
 		# shellcheck disable=SC2029
 		echo "$(echo


### PR DESCRIPTION
previous definition was not working and `--no-collector.<flag>` is consistent with the [node_exporter](https://github.com/prometheus/node_exporter) flags. 