### PR TITLE
only update do-agent repository in update.sh

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,7 +3,7 @@
 
 main() {
 	if command -v apt-get 2&>/dev/null; then
-		apt-get -qq update
+		apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/digitalocean-agent.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 		apt-get -qq install -y --only-upgrade do-agent
 	elif command -v yum 2&>/dev/null; then
 		yum -q -y update do-agent


### PR DESCRIPTION
Instead of running a brute force update to all repositories this restricts the update
to only the source file that is used by do-agent. 