### PR TITLE
Install fix

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,13 +51,13 @@ function install_apt() {
 	apt-get remove -y do-agent || :
 
 	echo "Installing apt repository..."
-	apt-get -qq update
-	apt-get install -y ca-certificates gnupg2 apt-utils
+	apt-get -qq update || true
+	apt-get -qq install -y ca-certificates gnupg2 apt-utils apt-transport-https
 	echo "deb ${REPO_HOST}/apt/${repo} main main" > /etc/apt/sources.list.d/digitalocean-agent.list
 	echo -n "Installing gpg key..."
 	curl -sL "${REPO_GPG_KEY}" | apt-key add -
-	apt-get -qq update
-	apt-get install -y do-agent
+	apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/digitalocean-agent.list"
+	apt-get -qq install -y do-agent
 }
 
 function install_rpm() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,7 +3,7 @@
 
 main() {
 	if command -v apt-get 2&>/dev/null; then
-		apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/digitalocean-agent.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+		apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/digitalocean-agent.list"
 		apt-get -qq install -y --only-upgrade do-agent
 	elif command -v yum 2&>/dev/null; then
 		yum --disablerepo="*" --enablerepo="digitalocean-agent" makecache


### PR DESCRIPTION
install.sh: 

* fixed an issue where apt-get update would cause install to fail if some repositories aren't available which shouldn't block installing.

* fixed an issue with debian where apt-get install would fail because apt-transport-https package wasn't installed

* only update agent repository after installing the sources.list.d

uat.sh:

* use the official install.sh script

* add boot_status command to check the status of the cloud-init boot

* print the image name in the output message of `create` which sometimes results in `null` when the create fails