### PR TITLE
Scraper custom log level

### DIFF
--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -219,7 +219,7 @@ func initCollectors() []prometheus.Collector {
 	}
 
 	if config.dbaas != "" {
-		k, err := collector.NewScraper("dodbaas", config.dbaas, nil, dbaasWhitelist, defaultTimeout)
+		k, err := collector.NewScraper("dodbaas", config.dbaas, nil, dbaasWhitelist, WithTimeout(defaultTimeout))
 		if err != nil {
 			log.Error("Failed to initialize DO DBaaS metrics collector: %+v", err)
 		} else {
@@ -254,7 +254,7 @@ func appendKubernetesCollectors(cols []prometheus.Collector) []prometheus.Collec
 	}
 	var kubernetesLabels []*dto.LabelPair
 	kubernetesLabels = append(kubernetesLabels, &dto.LabelPair{Name: &kubernetesClusterUUIDLabel, Value: &kubernetesClusterUUID})
-	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, defaultTimeout)
+	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, WithTimeout(defaultTimeout))
 	if err != nil {
 		log.Error("Failed to initialize DO Kubernetes metrics: %+v", err)
 		return cols

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -219,7 +219,7 @@ func initCollectors() []prometheus.Collector {
 	}
 
 	if config.dbaas != "" {
-		k, err := collector.NewScraper("dodbaas", config.dbaas, nil, dbaasWhitelist, WithTimeout(defaultTimeout))
+		k, err := collector.NewScraper("dodbaas", config.dbaas, nil, dbaasWhitelist, collector.WithTimeout(defaultTimeout))
 		if err != nil {
 			log.Error("Failed to initialize DO DBaaS metrics collector: %+v", err)
 		} else {
@@ -254,7 +254,7 @@ func appendKubernetesCollectors(cols []prometheus.Collector) []prometheus.Collec
 	}
 	var kubernetesLabels []*dto.LabelPair
 	kubernetesLabels = append(kubernetesLabels, &dto.LabelPair{Name: &kubernetesClusterUUIDLabel, Value: &kubernetesClusterUUID})
-	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, WithTimeout(defaultTimeout), WithLogLevel(log.LevelDebug))
+	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, collector.WithTimeout(defaultTimeout), collector.WithLogLevel(log.LevelDebug))
 	if err != nil {
 		log.Error("Failed to initialize DO Kubernetes metrics: %+v", err)
 		return cols

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -254,7 +254,7 @@ func appendKubernetesCollectors(cols []prometheus.Collector) []prometheus.Collec
 	}
 	var kubernetesLabels []*dto.LabelPair
 	kubernetesLabels = append(kubernetesLabels, &dto.LabelPair{Name: &kubernetesClusterUUIDLabel, Value: &kubernetesClusterUUID})
-	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, WithTimeout(defaultTimeout))
+	k, err := collector.NewScraper("dokubernetes", config.kubernetes, kubernetesLabels, k8sWhitelist, WithTimeout(defaultTimeout), WithLogLevel(log.LevelDebug))
 	if err != nil {
 		log.Error("Failed to initialize DO Kubernetes metrics: %+v", err)
 		return cols

--- a/pkg/collector/scraper_test.go
+++ b/pkg/collector/scraper_test.go
@@ -41,7 +41,7 @@ func TestScraper(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	s, err := NewScraper("testscraper", ts.URL, nil, nil, 30*time.Second)
+	s, err := NewScraper("testscraper", ts.URL, nil, nil, WithTimeout(30*time.Second))
 	require.NoError(t, err)
 
 	ch := make(chan prometheus.Metric)
@@ -67,7 +67,7 @@ func TestScraperAddsKubernetesClusterUUID(t *testing.T) {
 	clusterUUID := "123-345-678000"
 	var kubernetesLabels []*dto.LabelPair
 	kubernetesLabels = append(kubernetesLabels, &dto.LabelPair{Name: &kubernetesClusterUUID, Value: &clusterUUID})
-	s, err := NewScraper("testscraper", ts.URL, kubernetesLabels, nil, 30*time.Second)
+	s, err := NewScraper("testscraper", ts.URL, kubernetesLabels, nil, WithTimeout(30*time.Second))
 	require.NoError(t, err)
 
 	ch := make(chan prometheus.Metric)
@@ -99,7 +99,7 @@ func TestWhitelist(t *testing.T) {
 	defer ts.Close()
 
 	// Only scrape kube_configmap_created
-	s, err := NewScraper("testscraper", ts.URL, nil, map[string]bool{"kube_configmap_created": true}, 30*time.Second)
+	s, err := NewScraper("testscraper", ts.URL, nil, map[string]bool{"kube_configmap_created": true}, WithTimeout(30*time.Second))
 	require.NoError(t, err)
 
 	ch := make(chan prometheus.Metric)


### PR DESCRIPTION
Currently DOKS clusters that do not have kube-state-metrics installed (the default) end up emitting a pretty fair volume of error logs since the scraping fails.

This PR introduces the ability to inject a custom log level to the scraper on initialization (also moves timeouts to this pattern) and configures the kubernetes scraper to use the debug log level.

Not sure if this is the approach/pattern that you folks would like to adopt, so feel free to reject/change as you prefer.