### PR TITLE
Feat/in 2408/additional labels

### DIFF
--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -39,6 +39,7 @@ var (
 		dbaas            string
 		webListenAddress string
 		webListen        bool
+		additionalLabels []string
 	}
 
 	// additionalParams is a list of extra command line flags to append
@@ -110,6 +111,8 @@ func init() {
 	kingpin.Flag("web.listen-address", `write prometheus metrics to the specified port (ex. ":9100")`).
 		Default(defaultWebListenAddress).
 		StringVar(&config.webListenAddress)
+
+	kingpin.Flag("additional-label", "key value pairs for labels to add to all metrics (ex: user_id:1234)").StringsVar(&config.additionalLabels)
 }
 
 func initConfig() {

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/digitalocean/do-agent/internal/flags"
@@ -301,6 +302,14 @@ func convertToLabelPairs(s []string) []*dto.LabelPair {
 		vals := strings.SplitN(lbl, ":", 2)
 		if len(vals) != 2 { // require a key value pair
 			log.Fatal("Bad additional-label %s, must be in the format of <key>:<value>", lbl)
+		}
+
+		if !model.LabelName(vals[0]).IsValid() {
+			log.Fatal("Bad additional-label name %s", vals[0])
+		}
+
+		if !model.LabelValue(vals[1]).IsValid() {
+			log.Fatal("Bad additional-label value %s", vals[1])
 		}
 
 		l = append(l, &dto.LabelPair{

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -296,7 +296,7 @@ func disableCollectorFlag(name string) string {
 }
 
 func convertToLabelPairs(s []string) []*dto.LabelPair {
-	var l []*dto.LabelPair
+	l := []*dto.LabelPair{}
 	for _, lbl := range s {
 		vals := strings.SplitN(lbl, ":", 2)
 		if len(vals) != 2 { // require a key value pair

--- a/cmd/do-agent/config_test.go
+++ b/cmd/do-agent/config_test.go
@@ -87,8 +87,8 @@ func TestConvertLabelPairs(t *testing.T) {
 	require.Equal(t, []*dto.LabelPair{{Name: sPtr("user_id"), Value: sPtr("12:34:56")}}, pairs)
 
 	pairs = convertToLabelPairs([]string{})
-	require.Nil(t, pairs)
+	require.Empty(t, pairs)
 
 	pairs = convertToLabelPairs(nil)
-	require.Nil(t, pairs)
+	require.Empty(t, pairs)
 }

--- a/cmd/do-agent/config_test.go
+++ b/cmd/do-agent/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +72,23 @@ k8saas_dns_service_ip: "YES"`
 	require.Error(t, err)
 	require.Equal(t, err, errClusterUUIDNotFound)
 	assert.EqualValues(t, "", parsed)
+}
+
+func TestConvertLabelPairs(t *testing.T) {
+
+	sPtr := func(s string) *string { return &s }
+	pairs := convertToLabelPairs([]string{"user_id:1234"})
+	require.Equal(t, []*dto.LabelPair{{Name: sPtr("user_id"), Value: sPtr("1234")}}, pairs)
+
+	pairs = convertToLabelPairs([]string{"user_id:1234", "dbaas_cluster_uuid:ruiheiuqhf"})
+	require.Equal(t, []*dto.LabelPair{{Name: sPtr("user_id"), Value: sPtr("1234")}, {Name: sPtr("dbaas_cluster_uuid"), Value: sPtr("ruiheiuqhf")}}, pairs)
+
+	pairs = convertToLabelPairs([]string{"user_id:12:34:56"})
+	require.Equal(t, []*dto.LabelPair{{Name: sPtr("user_id"), Value: sPtr("12:34:56")}}, pairs)
+
+	pairs = convertToLabelPairs([]string{})
+	require.Nil(t, pairs)
+
+	pairs = convertToLabelPairs(nil)
+	require.Nil(t, pairs)
 }

--- a/pkg/decorate/labels.go
+++ b/pkg/decorate/labels.go
@@ -1,12 +1,14 @@
 package decorate
 
-import dto "github.com/prometheus/client_model/go"
+import (
+	dto "github.com/prometheus/client_model/go"
+)
 
-// Labels is a list of label pairs that need to be added/overwritten on all metrics
-type Labels []*dto.LabelPair
+// LabelAppender is a list of label pairs that need to be added on all metrics
+type LabelAppender []*dto.LabelPair
 
-// Decorate adds/overwritesa metric labels from its list
-func (l Labels) Decorate(mfs []*dto.MetricFamily) {
+// Decorate adds metric labels from its list
+func (l LabelAppender) Decorate(mfs []*dto.MetricFamily) {
 	for _, fam := range mfs {
 		metrics := fam.GetMetric()
 		for _, metric := range metrics {
@@ -16,6 +18,6 @@ func (l Labels) Decorate(mfs []*dto.MetricFamily) {
 }
 
 // Name is the name of this decorator
-func (Labels) Name() string {
-	return "Labels"
+func (LabelAppender) Name() string {
+	return "LabelsAppender"
 }

--- a/pkg/decorate/labels.go
+++ b/pkg/decorate/labels.go
@@ -1,0 +1,21 @@
+package decorate
+
+import dto "github.com/prometheus/client_model/go"
+
+// Labels is a list of label pairs that need to be added/overwritten on all metrics
+type Labels []*dto.LabelPair
+
+// Decorate adds/overwritesa metric labels from its list
+func (l Labels) Decorate(mfs []*dto.MetricFamily) {
+	for _, fam := range mfs {
+		metrics := fam.GetMetric()
+		for _, metric := range metrics {
+			metric.Label = append(metric.Label, l...)
+		}
+	}
+}
+
+// Name is the name of this decorator
+func (Labels) Name() string {
+	return "Labels"
+}

--- a/pkg/decorate/labels_test.go
+++ b/pkg/decorate/labels_test.go
@@ -1,0 +1,124 @@
+package decorate
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func sPtr(s string) *string {
+	return &s
+}
+
+func TestAppendLabels(t *testing.T) {
+
+	decorator := LabelAppender([]*dto.LabelPair{
+		{
+			Name:  sPtr("user_id"),
+			Value: sPtr("1234"),
+		},
+		{
+			Name:  sPtr("dbaas_uuid"),
+			Value: sPtr("hello-world"),
+		},
+	})
+
+	items := []*dto.MetricFamily{
+		{
+			Name: sPtr("sonar_cpu"),
+			Metric: []*dto.Metric{
+				{
+					Label: []*dto.LabelPair{
+						{
+							Name:  sPtr("some_name"),
+							Value: sPtr("some_value"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	final := []*dto.LabelPair{
+		{
+			Name:  sPtr("some_name"),
+			Value: sPtr("some_value"),
+		},
+		{
+			Name:  sPtr("user_id"),
+			Value: sPtr("1234"),
+		},
+		{
+			Name:  sPtr("dbaas_uuid"),
+			Value: sPtr("hello-world"),
+		},
+	}
+
+	// Append new labels
+	decorator.Decorate(items)
+	require.Equal(t, final, items[0].Metric[0].Label)
+}
+
+func TestAppendLabelsToEmptyLabels(t *testing.T) {
+	decorator := LabelAppender([]*dto.LabelPair{
+		{
+			Name:  sPtr("user_id"),
+			Value: sPtr("1234"),
+		},
+		{
+			Name:  sPtr("dbaas_uuid"),
+			Value: sPtr("hello-world"),
+		},
+	})
+
+	items := []*dto.MetricFamily{
+		{
+			Name: sPtr("sonar_cpu"),
+			Metric: []*dto.Metric{
+				{
+					Label: nil,
+				},
+			},
+		},
+	}
+
+	final := []*dto.LabelPair{
+		{
+			Name:  sPtr("user_id"),
+			Value: sPtr("1234"),
+		},
+		{
+			Name:  sPtr("dbaas_uuid"),
+			Value: sPtr("hello-world"),
+		},
+	}
+
+	// Append new labels
+	decorator.Decorate(items)
+	require.Equal(t, final, items[0].Metric[0].Label)
+}
+
+func TestAppendLabelsToEmptyMetric(t *testing.T) {
+	decorator := LabelAppender([]*dto.LabelPair{
+		{
+			Name:  sPtr("user_id"),
+			Value: sPtr("1234"),
+		},
+		{
+			Name:  sPtr("dbaas_uuid"),
+			Value: sPtr("hello-world"),
+		},
+	})
+
+	items := []*dto.MetricFamily{
+		{
+			Name:   sPtr("sonar_cpu"),
+			Metric: nil,
+		},
+	}
+
+	// Append labels; expect nothing to be appended
+	decorator.Decorate(items)
+	require.Equal(t, 0, len(items[0].Metric))
+}


### PR DESCRIPTION
Supports --additional-label flag which parses values in the format of key:value and uses them as label pair for all metrics.