### PR TITLE
IN-2421: don't obsolete debian and RPM packages when a new version is…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,6 @@ $(deb_package): $(base_package)
 		--force \
 		--depends cron \
 		--conflicts do-agent \
-		--replaces do-agent \
 		--deb-group nobody \
 		--deb-user do-agent \
 		-p $@ \
@@ -181,7 +180,6 @@ $(rpm_package): $(base_package)
 		--input-type deb \
 		--depends cronie \
 		--conflicts do-agent \
-		--replaces do-agent \
 		--rpm-group nobody \
 		--rpm-user do-agent \
 		--force \


### PR DESCRIPTION
… released.