### PR TITLE
Improve Dockerfile apt-get cache cleanup process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN set -x && \
         apt-get -qq update && \
         apt-get install -y ca-certificates dumb-init && \
-        apt-get autoclean
+        rm -rf /var/lib/apt/lists/*
 
 ADD target/do-agent-linux-amd64 /bin/do-agent
 


### PR DESCRIPTION
According to the official best practices document:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

Official Ubuntu images automatically run `apt-get clean`, so there is no need to do another `apt-get autoclean`,
what really need is to clean up the cache of index file - `rm -rf /var/lib/apt/lists/*`.