### PR TITLE
don't override init files on update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,12 @@ $(base_package): $(binary)
 		--log info \
 		--after-install packaging/scripts/after_install.sh \
 		--after-remove packaging/scripts/after_remove.sh \
+		--config-files /etc/init/do-agent.conf \
+		--config-files /etc/systemd/system/do-agent.service \
 		$<=/opt/digitalocean/bin/do-agent \
-		scripts/update.sh=/opt/digitalocean/do-agent/scripts/update.sh
+		scripts/update.sh=/opt/digitalocean/do-agent/scripts/update.sh \
+		packaging/etc/init/do-agent.conf=/etc/init/do-agent.conf \
+		packaging/etc/systemd/system/do-agent.service=/etc/systemd/system/do-agent.service
 .INTERMEDIATE: $(base_package)
 
 deb: $(deb_package)

--- a/packaging/etc/init/do-agent.conf
+++ b/packaging/etc/init/do-agent.conf
@@ -1,0 +1,16 @@
+# do-agent - An agent that collects system metrics.
+#
+# An agent that collects system metrics and transmits them to DigitalOcean.
+description "The DigitalOcean Monitoring Agent"
+author "DigitalOcean"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+console none
+normal exit 0 TERM
+kill timeout 5
+respawn
+
+script
+  exec su -s /bin/sh -c 'exec "\$0" "\$@"' do-agent -- /opt/digitalocean/bin/do-agent --syslog
+end script

--- a/packaging/etc/systemd/system/do-agent.service
+++ b/packaging/etc/systemd/system/do-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=The DigitalOcean Monitoring Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=do-agent
+ExecStart=/opt/digitalocean/bin/do-agent --syslog
+Restart=always
+
+OOMScoreAdjust=-900
+SyslogIdentifier=DigitalOceanAgent
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/scripts/after_install.sh
+++ b/packaging/scripts/after_install.sh
@@ -12,14 +12,9 @@ set -ue
 INSTALL_DIR=/opt/digitalocean/do-agent
 SVC_NAME=do-agent
 USERNAME=do-agent
-USERGROUP=nogroup
 CRON=/etc/cron.daily/do-agent
 INIT_SVC_FILE="/etc/init/${SVC_NAME}.conf"
 SYSTEMD_SVC_FILE="/etc/systemd/system/${SVC_NAME}.service"
-
-# fedora uses nobody instead of nogroup
-getent group nobody 2> /dev/null \
-	&& USERGROUP=nobody
 
 main() {
 	update_selinux
@@ -27,9 +22,11 @@ main() {
 	useradd -M --system $USERNAME || true
 
 	if command -v systemctl >/dev/null 2>&1; then
-		init_systemd
+		# systemd is used, remove the upstart script
+		rm -f "${INIT_SVC_FILE}"
 	elif command -v initctl >/dev/null 2>&1; then
-		init_upstart
+		# upstart is used, remove the systemd script
+		rm -f "${SYSTEMD_SVC_FILE}"
 	else
 		echo "Unknown init system. Exiting..." > /dev/stderr
 		exit 1
@@ -66,64 +63,4 @@ patch_updates() {
 	chmod +x "${CRON}"
 }
 
-init_systemd() {
-	echo "Creating ${SYSTEMD_SVC_FILE}..."
-	# cannot use symlink because of an old bug https://bugzilla.redhat.com/show_bug.cgi?id=955379
-	cat <<-EOF > "${SYSTEMD_SVC_FILE}"
-	[Unit]
-	Description=DigitalOcean do-agent agent
-	After=network-online.target
-	Wants=network-online.target
-
-	[Service]
-	User=${USERNAME}
-	Group=${USERGROUP}
-	ExecStart=/opt/digitalocean/bin/do-agent --syslog
-	Restart=always
-
-	OOMScoreAdjust=-900
-	SyslogIdentifier=DigitalOceanAgent
-	PrivateTmp=yes
-	ProtectSystem=full
-	ProtectHome=yes
-	NoNewPrivileges=yes
-
-	[Install]
-	WantedBy=multi-user.target
-	EOF
-
-	# --now is unsupported on older versions of debian/systemd
-	systemctl daemon-reload
-	systemctl enable -f ${SVC_NAME}
-	systemctl start ${SVC_NAME}
-}
-
-init_upstart() {
-	echo "Creating ${INIT_SVC_FILE}..."
-	cat <<-EOF > ${INIT_SVC_FILE}
-	# do-agent - An agent that collects system metrics.
-	#
-	# An agent that collects system metrics and transmits them to DigitalOcean.
-	description "The DigitalOcean Monitoring Agent"
-	author "DigitalOcean"
-
-	start on runlevel [2345]
-	stop on runlevel [!2345]
-	console none
-	normal exit 0 TERM
-	kill timeout 5
-	respawn
-
-	script
-	  exec su -s /bin/sh -c 'exec "\$0" "\$@"' ${USERNAME} -- /opt/digitalocean/bin/do-agent --syslog
-	end script
-	EOF
-
-	initctl reload-configuration
-	initctl start ${SVC_NAME}
-}
-
-# never put anything below this line. This is to prevent any partial execution
-# if curl ever interrupts the download prematurely. In that case, this script
-# will not execute since this is the last line in the script.
 main

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -8,7 +8,7 @@ main() {
 	export DEBIAN_FRONTEND="noninteractive"
 	if command -v apt-get 2&>/dev/null; then
 		apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/digitalocean-agent.list"
-		apt-get -qq install -y --only-upgrade do-agent
+		apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq install -y --only-upgrade do-agent
 	elif command -v yum 2&>/dev/null; then
 		yum -q -y --disablerepo="*" --enablerepo="digitalocean-agent" makecache
 		yum -q -y update do-agent


### PR DESCRIPTION
allows users to customize init scripts without losing changes on update