### PR TITLE
use apt-get purge when using install.sh to prevent config issues

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,7 @@ function main() {
 
 function install_apt() {
 	# forcefully remove any existing installations
-	apt-get remove -y do-agent >/dev/null 2>&1 || :
+	apt-get purge -y do-agent >/dev/null 2>&1 || :
 
 	echo "Installing apt repository..."
 	apt-get -qq update || true


### PR DESCRIPTION
The install script should be considered a sledge hammer. Anyone running the script should expect it to override any configuration files. Switching from remove to purge will do that.