### PR TITLE
increase scrape timeout

### DIFF
--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -134,7 +134,7 @@ func init() {
 	kingpin.Flag("process-topk", "number of top processes to scrape").Default("30").IntVar(&config.topK)
 
 	kingpin.Flag("scrape-timeout", "timeout for scraping metrics").
-		Default("10s").
+		Default("30s").
 		DurationVar(&config.scrapeTimeout)
 
 }


### PR DESCRIPTION
This PR increases the default scrape timeout to account for very large `kube-state-metrics` targets. 