### PR TITLE
Added AlmaLinux OS Support

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,7 @@ function main() {
 		debian|ubuntu)
 			install_apt
 			;;
-		centos|cloudlinux|fedora)
+		centos|cloudlinux|fedora|almalinux)
 			install_rpm
 			;;
 		*)
@@ -119,7 +119,7 @@ function check_dist() {
 		debian|ubuntu|centos|fedora)
 			echo "OK"
 			;;
-		cloudlinux)
+		cloudlinux|almalinux)
 			echo "WARN ${dist} is not officially supported. Attempting RPM install"
 			;;
 		*)


### PR DESCRIPTION
Added AlmaLinux OS (1:1 binary compatible fork of RHEL) to the Supported Operating System.

Moved to Officially Unsupported OS as per the comment in the PR-251 by @bsnyder788 