### PR TITLE
Change gnupg2 to gnupg for apt installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ function install_apt() {
 
 	echo "Installing apt repository..."
 	wait_for_apt && ( apt-get -qq update || true )
-	wait_for_apt && apt-get -qq install -y ca-certificates gnupg2 apt-utils apt-transport-https curl
+	wait_for_apt && apt-get -qq install -y ca-certificates gnupg apt-utils apt-transport-https curl
 	echo "deb ${REPO_HOST}/apt/${repo} main main" > /etc/apt/sources.list.d/digitalocean-agent.list
 	echo -n "Installing gpg key..."
 	curl -sL "${REPO_GPG_KEY}" | apt-key add -


### PR DESCRIPTION
This pull request is about changing `gnupg2` to `gnupg` for `apt` installs since this package is no longer available.

Related issue: #258