### PR TITLE
fix: change k8s node selector to `kubernetes.io/os`

### DIFF
--- a/deploy/do-agent.yaml
+++ b/deploy/do-agent.yaml
@@ -49,7 +49,7 @@ spec:
           - "--path.sysfs=/host/sys"
           - "--k8s-metrics-path=http://kube-state-metrics.kube-system.svc.cluster.local:8080/metrics"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
The node selector `beta.kubernetes.io/os` is deprecated and it is recommended to use `kubernetes.io/os`.