### PR TITLE
Stop using apt-key (fixes Ubuntu 22 warnings)

### DIFF
--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -24,6 +24,7 @@ repo="do-agent"
 
 dist="unknown"
 deb_list=/etc/apt/sources.list.d/digitalocean-agent.list
+deb_keyfile=/usr/share/keyrings/digitalocean-agent-keyring.gpg
 rpm_repo=/etc/yum.repos.d/digitalocean-agent.repo
 
 function main() {
@@ -62,9 +63,9 @@ function install_apt() {
 	echo "Installing apt repository..."
 	wait_for_apt && ( apt-get -qq update || true )
 	wait_for_apt && apt-get -qq install -y ca-certificates gnupg2 apt-utils apt-transport-https curl
-	echo "deb ${REPO_HOST}/apt/${repo} main main" > /etc/apt/sources.list.d/digitalocean-agent.list
+	echo "deb [signed-by=${deb_keyfile}] ${REPO_HOST}/apt/${repo} main main" >"${deb_list}"
 	echo -n "Installing gpg key..."
-	curl -sL "${REPO_GPG_KEY}" | apt-key add -
+	curl -sL "${REPO_GPG_KEY}" | gpg --dearmor >"${deb_keyfile}"
 	wait_for_apt && apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/digitalocean-agent.list"
 	wait_for_apt && apt-get -qq install -y do-agent
 }


### PR DESCRIPTION
Under Ubuntu22 and debian bullseye (stable) warnings are issued every time `apt-get update` is run: 
> W: https://repos.insights.digitalocean.com/apt/do-agent/dists/main/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.

This PR alters the do-agent install.sh script to follow the pattern used in the [droplet-agent install script](https://github.com/digitalocean/droplet-agent/blob/dde65fb2002d6e19677750fb689ea7ab27f11c62/packaging/scripts/install.sh#L160) to not use
`apt-key` because `apt-key` and `/etc/apt/trusted.gpg` are deprecated in Ubuntu22 and Debian bullseye.

Related [DO Community Question](https://www.digitalocean.com/community/questions/digitalocean-agent-key-deprecation-warning-in-ubuntu-22-04-jammy) (2022-06-19)

Fixes #268 (2022-06-20)
Fixes #273 (2022-11-09)

P.S. y'all might want to include something in the readme here and in https://github.com/digitalocean/droplet-agent/ to explicitly disambiguate and cross-link between the two repos.  It's be totally understandable for folks to confuse `do-agent` with `droplet-agent` (see [@hobhobuk's answer](https://www.digitalocean.com/community/questions/digitalocean-agent-key-deprecation-warning-in-ubuntu-22-04-jammy?comment=189319) in above linked DO Community Question for an example of that happening). 

P.P.S. Similarly I think it'd be totally appropriate to add a line to the top each install.sh script NAMING the product that's about to be installed and explicitly link to the associated GitHub repo.