### PR TITLE
Fix Improper Privilege Management CVE-2022-29526

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	go.uber.org/multierr v1.5.0 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/protobuf v1.22.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )


### PR DESCRIPTION
The syscall.Faccessat function checks whether the calling process can access a file. Faccessat contains a bug where it checks a file's group permission bits if the process's user is a member of the process's group rather than a member of the file's group.
```js
 if uint32(gid) == st.Gid || isGroupMember(gid) { 
```
```
	var fmode uint32
	if uint32(uid) == st.Uid {
		fmode = (st.Mode >> 6) & 7
	} else {
		var gid int
		if flags&_AT_EACCESS != 0 {
			gid = Getegid()
		} else {
			gid = Getgid()
		}

		if uint32(gid) == st.Gid || isGroupMember(gid) { // <-- this should be isGroupMember(st.Gid), not gid
			fmode = (st.Mode >> 3) & 7
		} else {
			fmode = st.Mode & 7
		}
	}
```
CVE-2022-29526
[CWE-269](https://cwe.mitre.org/data/definitions/269.html)
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
