### PR TITLE
Support collector logging in debug mode

### DIFF
--- a/pkg/collector/node.go
+++ b/pkg/collector/node.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-kit/kit/log"
+	"github.com/digitalocean/do-agent/internal/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -47,7 +47,7 @@ var metricWhitelist = []string{
 
 // NewNodeCollector creates a new prometheus NodeCollector
 func NewNodeCollector() (*NodeCollector, error) {
-	c, err := collector.NewNodeCollector(log.NewNopLogger())
+	c, err := collector.NewNodeCollector(log.GetCollectorLogger())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create NodeCollector")
 	}


### PR DESCRIPTION
Use a non-noop logger in debug mode so we can see the logs from the collectors.