### PR TITLE
Bug Fix protojson.Unmarshal function infinite loop when unmarshaling certain forms of invalid JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/ema/qdisc v0.0.0-20190904071900-b82c76788043 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/hodgesds/perf-utils v0.0.8 // indirect
 	github.com/lufia/iostat v1.1.0 // indirect
 	github.com/mattn/go-xmlrpc v0.0.3 // indirect
@@ -42,7 +42,7 @@ require (
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	golang.org/x/sys v0.5.0 // indirect
-	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 


### PR DESCRIPTION
encoding/protojson, internal/encoding/json: handle missing object values In internal/encoding/json, report an error when encountering `a }` when we are expecting an object field value. For example, the input `{"":}` now correctly results in an error at the closing } token. In encoding/protojson, check for an unexpected EOF token in skipJSONValue. This is redundant with the check in internal/encoding/json, but adds a bit more defense against any other similar bugs that might exist.


The protojson.Unmarshal function can enter an infinite loop when unmarshaling certain forms of invalid JSON. This condition can occur when unmarshaling into a message which contains a google.protobuf.Any value, or when the UnmarshalOptions.DiscardUnknown option is set.

```
@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {

	case ObjectClose:
		if len(d.openStack) == 0 ||
			d.lastToken.kind == comma ||
			d.lastToken.kind&(Name|comma) != 0 ||
			d.openStack[len(d.openStack)-1] != ObjectOpen {
			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
		}
```
CVE-2024-24786
CWE-835