### PR TITLE
chore: remove userdel from after_install.sh

### DIFF
--- a/packaging/scripts/after_install.sh
+++ b/packaging/scripts/after_install.sh
@@ -19,10 +19,6 @@ SYSTEMD_SVC_FILE="/etc/systemd/system/${SVC_NAME}.service"
 main() {
 	update_selinux
 
-	# fix for IN-2630
-	# TODO remove userdel in next release
-	# temporarily remove the do-agent and recreate it with no shell
-	userdel -f do-agent || true
 	useradd -s /bin/false -M --system $USERNAME || true
 
 	if command -v systemctl >/dev/null 2>&1; then


### PR DESCRIPTION
`userdel` was added to the after_install script to re-create users without a shell. The update has run, we can now remove the deletion.