### PR TITLE
DBAAS-6283: Fix creating gzip reader

### DIFF
--- a/pkg/collector/scraper.go
+++ b/pkg/collector/scraper.go
@@ -166,7 +166,11 @@ func (s *Scraper) readStream(ctx context.Context) (r io.ReadCloser, outerr error
 	}
 
 	reader, err := gzip.NewReader(bufio.NewReader(resp.Body))
-	return reader, fmt.Errorf("failed to create gzip reader: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+
+	return reader, nil
 }
 
 // Describe describes this collector


### PR DESCRIPTION
Existing code always returns an error when creating a reader for gzip encoded content.

2025-03-22 20:59:56.000 ERROR: 2025/03/22 20:59:56 /var/tmp/aiven-rpm-build/rpmbuild/BUILD/do-agent-3.17.0/_build/src/github.com/digitalocean/do-agent/pkg/collector/scraper.go:137: collection failed for "dodbaas": failed to create gzip reader: %!w(<nil>)