### PR TITLE
Log Improvement msg for push failure due to high count of metrics

### DIFF
--- a/pkg/writer/sonar.go
+++ b/pkg/writer/sonar.go
@@ -43,7 +43,8 @@ func NewSonar(client tsclient.Client, c *prometheus.CounterVec) *Sonar {
 func (s *Sonar) Write(mets []aggregate.MetricWithValue) error {
 	if len(mets) > s.client.MaxBatchSize() {
 		s.c.WithLabelValues("failure", "too many metrics").Inc()
-		return fmt.Errorf("cannot write metrics: %w", ErrTooManyMetrics)
+		return fmt.Errorf("cannot write metrics, current count: %d, max allowed: %d, error: %w",
+			len(mets), s.client.MaxBatchSize(), ErrTooManyMetrics)
 	}
 
 	for _, m := range mets {


### PR DESCRIPTION
added additional info in err msg to get current count metrics & allowed metrics for that specific user

<img width="1131" height="40" alt="Screenshot 2025-12-12 at 6 35 52 PM" src="https://github.com/user-attachments/assets/547870f5-a015-4b30-a951-a76ccf6ec367" />
