### PR TITLE
IN-6457: add DI metrics aggregation and whitelist for Insights

### DIFF
--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -198,6 +198,9 @@ var gpuAggregationSpec = map[string][]string{
 	"amd_gpu_gfx_activity":                                amdAggregatedLabels,
 	"amd_gpu_prof_sm_active":                              amdAggregatedLabels,
 }
+
+// DI metrics: drop high-cardinality labels we don't want to keep.
+// NOTE: do NOT include "le" because histogram buckets need it.
 var diLabelsToDrop = []string{
 	"instance",
 	"job",
@@ -208,62 +211,39 @@ var diLabelsToDrop = []string{
 }
 
 // diAggregationSpec lists DI metric names and which labels should be DROPPED.
-// Anything NOT in this list will be kept.
-// IMPORTANT: for histogram buckets, we MUST keep "le", so do NOT include "le" in diLabelsToDrop.
+// Anything NOT in this list will keep labels as-is.
 var diAggregationSpec = map[string][]string{
-	// Dedicated Inference GPU metrics
-	"gradient_infra_di_gpu_ecc_errors":                 diLabelsToDrop,
+	// DI GPU metrics
 	"gradient_infra_di_gpu_junction_temperature":       diLabelsToDrop,
-	"gradient_infra_di_gpu_memory_temperature":         diLabelsToDrop,
-	"gradient_infra_di_gpu_pcie_bandwidth":             diLabelsToDrop,
-	"gradient_infra_di_gpu_pcie_rx_bytes":              diLabelsToDrop,
-	"gradient_infra_di_gpu_pcie_tx_bytes":              diLabelsToDrop,
-	"gradient_infra_di_gpu_power_throttle":             diLabelsToDrop,
-	"gradient_infra_di_gpu_power_usage":                diLabelsToDrop,
-	"gradient_infra_di_gpu_thermal_throttle":           diLabelsToDrop,
 	"gradient_infra_di_gpu_total_vram":                 diLabelsToDrop,
 	"gradient_infra_di_gpu_used_vram":                  diLabelsToDrop,
 	"gradient_infra_di_gpu_free_vram":                  diLabelsToDrop,
-	"gradient_infra_di_gpu_interconnect_rx":            diLabelsToDrop,
-	"gradient_infra_di_gpu_interconnect_tx":            diLabelsToDrop,
-	"gradient_infra_di_gpu_interconnect_bandwidth":     diLabelsToDrop,
 	"gradient_infra_di_gpu_occupancy_percent":          diLabelsToDrop,
 	"gradient_infra_di_gpu_tensor_utilization_percent": diLabelsToDrop,
 
-	// Inference extension / gateway histograms
-	// bucket metrics must keep "le" -> do NOT drop it
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_bucket":        diLabelsToDrop,
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_bucket":       diLabelsToDrop,
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_bucket": diLabelsToDrop,
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_sum":           diLabelsToDrop,
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_count":         diLabelsToDrop,
-
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_sum":   diLabelsToDrop,
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_count": diLabelsToDrop,
-
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_sum":   diLabelsToDrop,
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_count": diLabelsToDrop,
-
-	// Objective request duration histogram
-	// bucket must keep "le" -> do NOT drop it
-	"gradient_infra_di_inference_objective_request_duration_seconds_bucket": diLabelsToDrop,
-	"gradient_infra_di_inference_objective_request_duration_seconds_sum":    diLabelsToDrop,
-	"gradient_infra_di_inference_objective_request_duration_seconds_count":  diLabelsToDrop,
-
-	// Objective request counters
+	// Objective counters
 	"gradient_infra_di_inference_objective_request_error_total": diLabelsToDrop,
 	"gradient_infra_di_inference_objective_request_total":       diLabelsToDrop,
 
-	// vLLM buckets (keep "le")
-	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           diLabelsToDrop,
-	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           diLabelsToDrop,
-	"gradient_infra_di_vllm:request_decode_time_seconds_bucket":           diLabelsToDrop,
-	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": diLabelsToDrop,
-	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           diLabelsToDrop,
-
-	// vLLM non-bucket
+	// vLLM non-histogram metrics
 	"gradient_infra_di_vllm:generation_tokens_total": diLabelsToDrop,
-	"gradient_infra_di_vllm:kv_cache_usage_perc":     diLabelsToDrop,
 	"gradient_infra_di_vllm:num_requests_running":    diLabelsToDrop,
 	"gradient_infra_di_vllm:num_requests_waiting":    diLabelsToDrop,
+
+	// vLLM histograms – flattened (_bucket / _sum / _count)
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_sum":    diLabelsToDrop,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_count":  diLabelsToDrop,
+
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_sum":    diLabelsToDrop,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_count":  diLabelsToDrop,
+
+	"gradient_infra_di_vllm:request_decode_time_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:request_decode_time_seconds_sum":    diLabelsToDrop,
+	"gradient_infra_di_vllm:request_decode_time_seconds_count":  diLabelsToDrop,
+
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_sum":    diLabelsToDrop,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_count":  diLabelsToDrop,
 }

--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -235,6 +235,14 @@ var diAggregationSpec = map[string][]string{
 	"gradient_infra_di_inference_extension_plugin_duration_seconds_bucket":        diLabelsToDrop,
 	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_bucket":       diLabelsToDrop,
 	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_sum":           diLabelsToDrop,
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_count":         diLabelsToDrop,
+
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_sum":   diLabelsToDrop,
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_count": diLabelsToDrop,
+
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_sum":   diLabelsToDrop,
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_count": diLabelsToDrop,
 
 	// Objective request duration histogram
 	// bucket must keep "le" -> do NOT drop it

--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -198,3 +198,64 @@ var gpuAggregationSpec = map[string][]string{
 	"amd_gpu_gfx_activity":                                amdAggregatedLabels,
 	"amd_gpu_prof_sm_active":                              amdAggregatedLabels,
 }
+var diLabelsToDrop = []string{
+	"instance",
+	"job",
+	"pod",
+	"otel_scope_name",
+	"otel_scope_schema_url",
+	"otel_scope_version",
+}
+
+// diAggregationSpec lists DI metric names and which labels should be DROPPED.
+// Anything NOT in this list will be kept.
+// IMPORTANT: for histogram buckets, we MUST keep "le", so do NOT include "le" in diLabelsToDrop.
+var diAggregationSpec = map[string][]string{
+	// Dedicated Inference GPU metrics
+	"gradient_infra_di_gpu_ecc_errors":                 diLabelsToDrop,
+	"gradient_infra_di_gpu_junction_temperature":       diLabelsToDrop,
+	"gradient_infra_di_gpu_memory_temperature":         diLabelsToDrop,
+	"gradient_infra_di_gpu_pcie_bandwidth":             diLabelsToDrop,
+	"gradient_infra_di_gpu_pcie_rx_bytes":              diLabelsToDrop,
+	"gradient_infra_di_gpu_pcie_tx_bytes":              diLabelsToDrop,
+	"gradient_infra_di_gpu_power_throttle":             diLabelsToDrop,
+	"gradient_infra_di_gpu_power_usage":                diLabelsToDrop,
+	"gradient_infra_di_gpu_thermal_throttle":           diLabelsToDrop,
+	"gradient_infra_di_gpu_total_vram":                 diLabelsToDrop,
+	"gradient_infra_di_gpu_used_vram":                  diLabelsToDrop,
+	"gradient_infra_di_gpu_free_vram":                  diLabelsToDrop,
+	"gradient_infra_di_gpu_interconnect_rx":            diLabelsToDrop,
+	"gradient_infra_di_gpu_interconnect_tx":            diLabelsToDrop,
+	"gradient_infra_di_gpu_interconnect_bandwidth":     diLabelsToDrop,
+	"gradient_infra_di_gpu_occupancy_percent":          diLabelsToDrop,
+	"gradient_infra_di_gpu_tensor_utilization_percent": diLabelsToDrop,
+
+	// Inference extension / gateway histograms
+	// bucket metrics must keep "le" -> do NOT drop it
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_bucket":        diLabelsToDrop,
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_bucket":       diLabelsToDrop,
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_bucket": diLabelsToDrop,
+
+	// Objective request duration histogram
+	// bucket must keep "le" -> do NOT drop it
+	"gradient_infra_di_inference_objective_request_duration_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_inference_objective_request_duration_seconds_sum":    diLabelsToDrop,
+	"gradient_infra_di_inference_objective_request_duration_seconds_count":  diLabelsToDrop,
+
+	// Objective request counters
+	"gradient_infra_di_inference_objective_request_error_total": diLabelsToDrop,
+	"gradient_infra_di_inference_objective_request_total":       diLabelsToDrop,
+
+	// vLLM buckets (keep "le")
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           diLabelsToDrop,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           diLabelsToDrop,
+	"gradient_infra_di_vllm:request_decode_time_seconds_bucket":           diLabelsToDrop,
+	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           diLabelsToDrop,
+
+	// vLLM non-bucket
+	"gradient_infra_di_vllm:generation_tokens_total": diLabelsToDrop,
+	"gradient_infra_di_vllm:kv_cache_usage_perc":     diLabelsToDrop,
+	"gradient_infra_di_vllm:num_requests_running":    diLabelsToDrop,
+	"gradient_infra_di_vllm:num_requests_waiting":    diLabelsToDrop,
+}

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -47,7 +47,6 @@ var (
 		defaultMaxMetricLength int
 		promAddr               string
 		gpuMetricsPath         string
-		diMetricsPath          string
 		topK                   int
 		scrapeTimeout          time.Duration
 	}
@@ -127,9 +126,6 @@ func init() {
 
 	kingpin.Flag("gpu-metrics-path", "enable GPU metrics collection from a prometheus endpoint (e.g., AMD device-metrics-exporter)").
 		StringVar(&config.gpuMetricsPath)
-
-	kingpin.Flag("di-metrics-address", "Dedicated Inference / DI metrics endpoint to scrape").
-		StringVar(&config.diMetricsPath)
 
 	kingpin.Flag("web.listen", "enable a local endpoint for scrapeable prometheus metrics as well").
 		Default("false").
@@ -262,11 +258,6 @@ func initAggregatorSpecs() map[string][]string {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
 	}
-	if config.diMetricsPath != "" {
-		for k, v := range diAggregationSpec {
-			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
-		}
-	}
 
 	return aggregateSpecs
 }
@@ -348,15 +339,6 @@ func initCollectors() []prometheus.Collector {
 			log.Error("Failed to initialize GPU metrics collector: %+v", err)
 		} else {
 			cols = append(cols, gpu)
-		}
-	}
-
-	if config.diMetricsPath != "" {
-		di, err := collector.NewScraper("di", config.diMetricsPath, nil, diWhitelist, collector.WithTimeout(config.scrapeTimeout))
-		if err != nil {
-			log.Error("Failed to initialize DI metrics collector: %+v", err)
-		} else {
-			cols = append(cols, di)
 		}
 	}
 

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -257,6 +257,10 @@ func initAggregatorSpecs() map[string][]string {
 		for k, v := range gpuAggregationSpec {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
+		//add DI label-drop rules too
+		for k, v := range diAggregationSpec {
+			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
+		}
 	}
 
 	return aggregateSpecs
@@ -334,7 +338,16 @@ func initCollectors() []prometheus.Collector {
 	}
 
 	if config.gpuMetricsPath != "" {
-		gpu, err := collector.NewScraper("gpu", config.gpuMetricsPath, nil, gpuWhitelist, collector.WithTimeout(config.scrapeTimeout))
+		//merge GPU + DI allowlist so DI metrics are not dropped at scrape time
+		wl := map[string]bool{}
+		for k, v := range gpuWhitelist {
+			wl[k] = v
+		}
+		for k, v := range diWhitelist {
+			wl[k] = v
+		}
+
+		gpu, err := collector.NewScraper("gpu", config.gpuMetricsPath, nil, wl, collector.WithTimeout(config.scrapeTimeout))
 		if err != nil {
 			log.Error("Failed to initialize GPU metrics collector: %+v", err)
 		} else {

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -47,6 +47,7 @@ var (
 		defaultMaxMetricLength int
 		promAddr               string
 		gpuMetricsPath         string
+		diMetricsPath          string
 		topK                   int
 		scrapeTimeout          time.Duration
 	}
@@ -126,6 +127,9 @@ func init() {
 
 	kingpin.Flag("gpu-metrics-path", "enable GPU metrics collection from a prometheus endpoint (e.g., AMD device-metrics-exporter)").
 		StringVar(&config.gpuMetricsPath)
+
+	kingpin.Flag("di-metrics-path", "enable Dedicated Inference (DI) metrics collection from a prometheus endpoint").
+		StringVar(&config.diMetricsPath)
 
 	kingpin.Flag("web.listen", "enable a local endpoint for scrapeable prometheus metrics as well").
 		Default("false").
@@ -257,7 +261,8 @@ func initAggregatorSpecs() map[string][]string {
 		for k, v := range gpuAggregationSpec {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
-		//add DI label-drop rules too
+	}
+	if config.diMetricsPath != "" {
 		for k, v := range diAggregationSpec {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
@@ -336,25 +341,28 @@ func initCollectors() []prometheus.Collector {
 			cols = append(cols, k)
 		}
 	}
+	if config.diMetricsPath != "" {
+		opts := []collector.Option{
+			collector.WithTimeout(config.scrapeTimeout),
+			collector.WithFlattenHistograms(),
+		}
+
+		di, err := collector.NewScraper("di", config.diMetricsPath, nil, diWhitelist, opts...)
+		if err != nil {
+			log.Error("Failed to initialize DI metrics collector: %+v", err)
+		} else {
+			cols = append(cols, di)
+		}
+	}
 
 	if config.gpuMetricsPath != "" {
-		//merge GPU + DI allowlist so DI metrics are not dropped at scrape time
-		wl := map[string]bool{}
-		for k, v := range gpuWhitelist {
-			wl[k] = v
-		}
-		for k, v := range diWhitelist {
-			wl[k] = v
-		}
-
-		gpu, err := collector.NewScraper("gpu", config.gpuMetricsPath, nil, wl, collector.WithTimeout(config.scrapeTimeout))
+		gpu, err := collector.NewScraper("gpu", config.gpuMetricsPath, nil, gpuWhitelist, collector.WithTimeout(config.scrapeTimeout))
 		if err != nil {
 			log.Error("Failed to initialize GPU metrics collector: %+v", err)
 		} else {
 			cols = append(cols, gpu)
 		}
 	}
-
 	// create the default DO agent to collect metrics about
 	// this device
 	if !config.noNode {

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -47,6 +47,7 @@ var (
 		defaultMaxMetricLength int
 		promAddr               string
 		gpuMetricsPath         string
+		diMetricsPath          string
 		topK                   int
 		scrapeTimeout          time.Duration
 	}
@@ -126,6 +127,9 @@ func init() {
 
 	kingpin.Flag("gpu-metrics-path", "enable GPU metrics collection from a prometheus endpoint (e.g., AMD device-metrics-exporter)").
 		StringVar(&config.gpuMetricsPath)
+
+	kingpin.Flag("di-metrics-address", "Dedicated Inference / DI metrics endpoint to scrape").
+		StringVar(&config.diMetricsPath)
 
 	kingpin.Flag("web.listen", "enable a local endpoint for scrapeable prometheus metrics as well").
 		Default("false").
@@ -258,6 +262,11 @@ func initAggregatorSpecs() map[string][]string {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
 	}
+	if config.diMetricsPath != "" {
+		for k, v := range diAggregationSpec {
+			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
+		}
+	}
 
 	return aggregateSpecs
 }
@@ -339,6 +348,15 @@ func initCollectors() []prometheus.Collector {
 			log.Error("Failed to initialize GPU metrics collector: %+v", err)
 		} else {
 			cols = append(cols, gpu)
+		}
+	}
+
+	if config.diMetricsPath != "" {
+		di, err := collector.NewScraper("di", config.diMetricsPath, nil, diWhitelist, collector.WithTimeout(config.scrapeTimeout))
+		if err != nil {
+			log.Error("Failed to initialize DI metrics collector: %+v", err)
+		} else {
+			cols = append(cols, di)
 		}
 	}
 

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -250,59 +250,36 @@ var gpuWhitelist = map[string]bool{
 	"amd_gpu_prof_sm_active":                              true,
 }
 var diWhitelist = map[string]bool{
-	// Dedicated Inference GPU metrics
-	"gradient_infra_di_gpu_ecc_errors":                 true,
+	// DI GPU metrics
 	"gradient_infra_di_gpu_junction_temperature":       true,
-	"gradient_infra_di_gpu_memory_temperature":         true,
-	"gradient_infra_di_gpu_pcie_bandwidth":             true,
-	"gradient_infra_di_gpu_pcie_rx_bytes":              true,
-	"gradient_infra_di_gpu_pcie_tx_bytes":              true,
-	"gradient_infra_di_gpu_power_throttle":             true,
-	"gradient_infra_di_gpu_power_usage":                true,
-	"gradient_infra_di_gpu_thermal_throttle":           true,
 	"gradient_infra_di_gpu_total_vram":                 true,
 	"gradient_infra_di_gpu_used_vram":                  true,
 	"gradient_infra_di_gpu_free_vram":                  true,
-	"gradient_infra_di_gpu_interconnect_rx":            true,
-	"gradient_infra_di_gpu_interconnect_tx":            true,
-	"gradient_infra_di_gpu_interconnect_bandwidth":     true,
 	"gradient_infra_di_gpu_occupancy_percent":          true,
 	"gradient_infra_di_gpu_tensor_utilization_percent": true,
 
-	// Inference extension / gateway histograms (base + bucket/sum/count)
-	"gradient_infra_di_inference_extension_plugin_duration_seconds":        true,
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_bucket": true,
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_sum":    true,
-	"gradient_infra_di_inference_extension_plugin_duration_seconds_count":  true,
-
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes":        true,
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_bucket": true,
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_sum":    true,
-	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_count":  true,
-
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds":        true,
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_bucket": true,
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_sum":    true,
-	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_count":  true,
-
-	// Objective request counters
+	// Objective counters
 	"gradient_infra_di_inference_objective_request_error_total": true,
 	"gradient_infra_di_inference_objective_request_total":       true,
 
-	// Objective request duration histogram (base + bucket/sum/count)
-	"gradient_infra_di_inference_objective_request_duration_seconds":        true,
-	"gradient_infra_di_inference_objective_request_duration_seconds_bucket": true,
-	"gradient_infra_di_inference_objective_request_duration_seconds_sum":    true,
-	"gradient_infra_di_inference_objective_request_duration_seconds_count":  true,
+	// vLLM
 
-	// vLLM metrics (histograms need base + bucket/sum/count if you expect sum/count to exist)
-	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           true,
-	"gradient_infra_di_vllm:generation_tokens_total":                      true,
-	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           true,
-	"gradient_infra_di_vllm:kv_cache_usage_perc":                          true,
-	"gradient_infra_di_vllm:num_requests_running":                         true,
-	"gradient_infra_di_vllm:num_requests_waiting":                         true,
-	"gradient_infra_di_vllm:request_decode_time_seconds_bucket":           true,
-	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": true,
-	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           true,
+	"gradient_infra_di_vllm:generation_tokens_total":            true,
+	"gradient_infra_di_vllm:num_requests_running":               true,
+	"gradient_infra_di_vllm:num_requests_waiting":               true,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket": true,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_sum":    true,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_count":  true,
+
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket": true,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_sum":    true,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_count":  true,
+
+	"gradient_infra_di_vllm:request_decode_time_seconds_bucket": true,
+	"gradient_infra_di_vllm:request_decode_time_seconds_sum":    true,
+	"gradient_infra_di_vllm:request_decode_time_seconds_count":  true,
+
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket": true,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_sum":    true,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_count":  true,
 }

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -249,3 +249,60 @@ var gpuWhitelist = map[string]bool{
 	"amd_gpu_gfx_activity":                                true,
 	"amd_gpu_prof_sm_active":                              true,
 }
+var diWhitelist = map[string]bool{
+	// Dedicated Inference GPU metrics
+	"gradient_infra_di_gpu_ecc_errors":                 true,
+	"gradient_infra_di_gpu_junction_temperature":       true,
+	"gradient_infra_di_gpu_memory_temperature":         true,
+	"gradient_infra_di_gpu_pcie_bandwidth":             true,
+	"gradient_infra_di_gpu_pcie_rx_bytes":              true,
+	"gradient_infra_di_gpu_pcie_tx_bytes":              true,
+	"gradient_infra_di_gpu_power_throttle":             true,
+	"gradient_infra_di_gpu_power_usage":                true,
+	"gradient_infra_di_gpu_thermal_throttle":           true,
+	"gradient_infra_di_gpu_total_vram":                 true,
+	"gradient_infra_di_gpu_used_vram":                  true,
+	"gradient_infra_di_gpu_free_vram":                  true,
+	"gradient_infra_di_gpu_interconnect_rx":            true,
+	"gradient_infra_di_gpu_interconnect_tx":            true,
+	"gradient_infra_di_gpu_interconnect_bandwidth":     true,
+	"gradient_infra_di_gpu_occupancy_percent":          true,
+	"gradient_infra_di_gpu_tensor_utilization_percent": true,
+
+	// Inference extension / gateway histograms (base + bucket/sum/count)
+	"gradient_infra_di_inference_extension_plugin_duration_seconds":        true,
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_bucket": true,
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_sum":    true,
+	"gradient_infra_di_inference_extension_plugin_duration_seconds_count":  true,
+
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes":        true,
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_bucket": true,
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_sum":    true,
+	"gradient_infra_di_inference_extension_prefix_indexer_hit_bytes_count":  true,
+
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds":        true,
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_bucket": true,
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_sum":    true,
+	"gradient_infra_di_inference_extension_scheduler_e2e_duration_seconds_count":  true,
+
+	// Objective request counters
+	"gradient_infra_di_inference_objective_request_error_total": true,
+	"gradient_infra_di_inference_objective_request_total":       true,
+
+	// Objective request duration histogram (base + bucket/sum/count)
+	"gradient_infra_di_inference_objective_request_duration_seconds":        true,
+	"gradient_infra_di_inference_objective_request_duration_seconds_bucket": true,
+	"gradient_infra_di_inference_objective_request_duration_seconds_sum":    true,
+	"gradient_infra_di_inference_objective_request_duration_seconds_count":  true,
+
+	// vLLM metrics (histograms need base + bucket/sum/count if you expect sum/count to exist)
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           true,
+	"gradient_infra_di_vllm:generation_tokens_total":                      true,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           true,
+	"gradient_infra_di_vllm:kv_cache_usage_perc":                          true,
+	"gradient_infra_di_vllm:num_requests_running":                         true,
+	"gradient_infra_di_vllm:num_requests_waiting":                         true,
+	"gradient_infra_di_vllm:request_decode_time_seconds_bucket":           true,
+	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": true,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           true,
+}

--- a/pkg/collector/scraper.go
+++ b/pkg/collector/scraper.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -21,10 +22,11 @@ import (
 var defaultScrapeTimeout = 5 * time.Second
 
 type scraperOpts struct {
-	timeout         time.Duration
-	logLevel        log.Level
-	bearerToken     string
-	bearerTokenFile string
+	timeout           time.Duration
+	logLevel          log.Level
+	flattenHistograms bool
+	bearerToken       string
+	bearerTokenFile   string
 }
 
 // Option is used to configure optional scraper options.
@@ -55,6 +57,11 @@ func WithTimeout(d time.Duration) Option {
 func WithLogLevel(l log.Level) Option {
 	return func(o *scraperOpts) {
 		o.logLevel = l
+	}
+}
+func WithFlattenHistograms() Option {
+	return func(o *scraperOpts) {
+		o.flattenHistograms = true
 	}
 }
 
@@ -93,6 +100,7 @@ func NewScraper(name, metricsEndpoint string, extraMetricLabels []*dto.LabelPair
 		name:              name,
 		extraMetricLabels: extraMetricLabels,
 		whitelist:         whitelist,
+		flattenHistograms: defOpts.flattenHistograms,
 		timeout:           defOpts.timeout,
 		logLevel:          defOpts.logLevel,
 		client:            client,
@@ -118,6 +126,7 @@ type Scraper struct {
 	req                *http.Request
 	client             *http.Client
 	name               string
+	flattenHistograms  bool
 	whitelist          map[string]bool
 	extraMetricLabels  []*dto.LabelPair
 	scrapeDurationDesc *prometheus.Desc
@@ -217,7 +226,7 @@ func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) (oute
 		if s.FilterMetric(mf) {
 			continue
 		}
-		convertMetricFamily(mf, ch, s.extraMetricLabels)
+		convertMetricFamily(mf, ch, s.extraMetricLabels, s.flattenHistograms)
 	}
 
 	return nil
@@ -230,11 +239,21 @@ func (s *Scraper) Name() string {
 
 // FilterMetric returns true if the metric should be skipped (filtered out)
 func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
-	if len(s.whitelist) == 0 { // if no whitelist treat all metrics as valid
+	if len(s.whitelist) == 0 {
 		return false
 	}
 
-	return !s.whitelist[*metricFamily.Name]
+	name := metricFamily.GetName()
+
+	// If we flatten histograms, the family name will be the base name (no suffix),
+	// but the whitelist contains *_bucket/_sum/_count.
+	if s.flattenHistograms && metricFamily.GetType() == dto.MetricType_HISTOGRAM {
+		if s.whitelist[name+"_bucket"] || s.whitelist[name+"_sum"] || s.whitelist[name+"_count"] {
+			return false
+		}
+	}
+
+	return !s.whitelist[name]
 }
 
 // convertMetricFamily converts the dto metrics parsed from the expfmt package
@@ -243,7 +262,7 @@ func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
 // this was copied and extended/refactored from github.com/prometheus/node_exporter
 // see https://github.com/prometheus/node_exporter/blob/f56e8fcdf48ead56f1f149dbf1301ac028ef589b/collector/textfile.go#L63
 // for more details
-func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric, extraLabels []*dto.LabelPair) {
+func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric, extraLabels []*dto.LabelPair, flattenHistograms bool) {
 	var valType prometheus.ValueType
 	var val float64
 
@@ -282,19 +301,63 @@ func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Me
 				quantiles, values...,
 			)
 		case dto.MetricType_HISTOGRAM:
-			buckets := map[float64]uint64{}
-			for _, b := range metric.Histogram.Bucket {
-				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
+			// Emit Prometheus histogram as separate *_bucket, *_sum, *_count series
+			// so downstream systems that don't support native Histogram types still get data.
+			if !flattenHistograms {
+				buckets := map[float64]uint64{}
+				for _, b := range metric.Histogram.Bucket {
+					buckets[b.GetUpperBound()] = b.GetCumulativeCount()
+				}
+				ch <- prometheus.MustNewConstHistogram(
+					prometheus.NewDesc(*metricFamily.Name, metricFamily.GetHelp(), names, nil),
+					metric.Histogram.GetSampleCount(),
+					metric.Histogram.GetSampleSum(),
+					buckets, values...,
+				)
+				break
 			}
-			ch <- prometheus.MustNewConstHistogram(
+			// 1) buckets
+			for _, b := range metric.Histogram.Bucket {
+				// add "le" label
+				bucketNames := append(append([]string{}, names...), "le")
+
+				le := fmt.Sprintf("%g", b.GetUpperBound())
+				if math.IsInf(b.GetUpperBound(), 1) {
+					le = "+Inf"
+				}
+
+				bucketValues := append(append([]string{}, values...), le)
+
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(
+						*metricFamily.Name+"_bucket",
+						metricFamily.GetHelp(),
+						bucketNames, nil,
+					),
+					prometheus.CounterValue,
+					float64(b.GetCumulativeCount()),
+					bucketValues...,
+				)
+			}
+
+			// 2) sum
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(*metricFamily.Name+"_sum", metricFamily.GetHelp(), names, nil),
+				prometheus.GaugeValue,
+				metric.Histogram.GetSampleSum(),
+				values...,
+			)
+
+			// 3) count
+			ch <- prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
-					*metricFamily.Name,
+					*metricFamily.Name+"_count",
 					metricFamily.GetHelp(),
 					names, nil,
 				),
-				metric.Histogram.GetSampleCount(),
-				metric.Histogram.GetSampleSum(),
-				buckets, values...,
+				prometheus.CounterValue,
+				float64(metric.Histogram.GetSampleCount()),
+				values...,
 			)
 		default:
 			log.Error("unknown metric type %q", metricType.String())

--- a/pkg/collector/scraper.go
+++ b/pkg/collector/scraper.go
@@ -68,7 +68,6 @@ func NewScraper(name, metricsEndpoint string, extraMetricLabels []*dto.LabelPair
 	for _, opt := range opts {
 		opt(defOpts)
 	}
-
 	// setup http client, add auth roundtrippers
 	client := clients.NewHTTP(defOpts.timeout)
 	if defOpts.bearerTokenFile != "" {
@@ -111,7 +110,6 @@ func NewScraper(name, metricsEndpoint string, extraMetricLabels []*dto.LabelPair
 	}, nil
 }
 
-// Scraper is a remote metric scraper that scrapes HTTP endpoints
 type Scraper struct {
 	timeout            time.Duration
 	logLevel           log.Level
@@ -124,7 +122,6 @@ type Scraper struct {
 	scrapeSuccessDesc  *prometheus.Desc
 }
 
-// log emits log messages respecting the scraper's log level.
 func (s *Scraper) log(msg string, params ...interface{}) {
 	var logFunc func(msg string, params ...interface{})
 	switch s.logLevel {
@@ -133,7 +130,6 @@ func (s *Scraper) log(msg string, params ...interface{}) {
 	case log.LevelError:
 		logFunc = log.Error
 	}
-
 	logFunc(msg, params...)
 }
 
@@ -145,11 +141,7 @@ func (s *Scraper) readStream(ctx context.Context) (r io.ReadCloser, outerr error
 		if outerr == nil || r == nil {
 			return
 		}
-		if err := r.Close(); err != nil {
-			// This should not happen, but if it does it'll be nice
-			// to know why we have a bunch of unclosed messages
-			s.log("failed to close stream on error: %s", err)
-		}
+		_ = r.Close()
 	}()
 
 	resp, err := s.client.Do(s.req.WithContext(ctx))
@@ -201,7 +193,7 @@ func (s *Scraper) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) (outerr error) {
+func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) error {
 	stream, err := s.readStream(ctx)
 	if err != nil {
 		return err
@@ -219,7 +211,6 @@ func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) (oute
 		}
 		convertMetricFamily(mf, ch, s.extraMetricLabels)
 	}
-
 	return nil
 }
 
@@ -230,10 +221,9 @@ func (s *Scraper) Name() string {
 
 // FilterMetric returns true if the metric should be skipped (filtered out)
 func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
-	if len(s.whitelist) == 0 { // if no whitelist treat all metrics as valid
+	if len(s.whitelist) == 0 {
 		return false
 	}
-
 	return !s.whitelist[*metricFamily.Name]
 }
 
@@ -244,70 +234,59 @@ func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
 // see https://github.com/prometheus/node_exporter/blob/f56e8fcdf48ead56f1f149dbf1301ac028ef589b/collector/textfile.go#L63
 // for more details
 func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric, extraLabels []*dto.LabelPair) {
-	var valType prometheus.ValueType
-	var val float64
-
 	allLabelNames := getAllLabelNames(metricFamily, extraLabels)
 
 	for _, metric := range metricFamily.Metric {
 		names, values := getLabelNamesAndValues(metric, extraLabels, allLabelNames)
 
-		metricType := metricFamily.GetType()
-		switch metricType {
+		switch metricFamily.GetType() {
+
 		case dto.MetricType_COUNTER:
-			valType = prometheus.CounterValue
-			val = metric.Counter.GetValue()
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(*metricFamily.Name, metricFamily.GetHelp(), names, nil),
+				prometheus.CounterValue,
+				metric.Counter.GetValue(),
+				values...,
+			)
 
 		case dto.MetricType_GAUGE:
-			valType = prometheus.GaugeValue
-			val = metric.Gauge.GetValue()
-
-		case dto.MetricType_UNTYPED:
-			valType = prometheus.UntypedValue
-			val = metric.Untyped.GetValue()
-
-		case dto.MetricType_SUMMARY:
-			quantiles := map[float64]float64{}
-			for _, q := range metric.Summary.Quantile {
-				quantiles[q.GetQuantile()] = q.GetValue()
-			}
-			ch <- prometheus.MustNewConstSummary(
-				prometheus.NewDesc(
-					*metricFamily.Name,
-					metricFamily.GetHelp(),
-					names, nil,
-				),
-				metric.Summary.GetSampleCount(),
-				metric.Summary.GetSampleSum(),
-				quantiles, values...,
-			)
-		case dto.MetricType_HISTOGRAM:
-			buckets := map[float64]uint64{}
-			for _, b := range metric.Histogram.Bucket {
-				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
-			}
-			ch <- prometheus.MustNewConstHistogram(
-				prometheus.NewDesc(
-					*metricFamily.Name,
-					metricFamily.GetHelp(),
-					names, nil,
-				),
-				metric.Histogram.GetSampleCount(),
-				metric.Histogram.GetSampleSum(),
-				buckets, values...,
-			)
-		default:
-			log.Error("unknown metric type %q", metricType.String())
-			continue
-		}
-		if metricType == dto.MetricType_GAUGE || metricType == dto.MetricType_COUNTER || metricType == dto.MetricType_UNTYPED {
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
-					*metricFamily.Name,
-					metricFamily.GetHelp(),
-					names, nil,
-				),
-				valType, val, values...,
+				prometheus.NewDesc(*metricFamily.Name, metricFamily.GetHelp(), names, nil),
+				prometheus.GaugeValue,
+				metric.Gauge.GetValue(),
+				values...,
+			)
+
+		case dto.MetricType_HISTOGRAM:
+			base := metricFamily.GetName()
+
+			// buckets
+			for _, b := range metric.Histogram.Bucket {
+				bucketNames := append(names, "le")
+				bucketValues := append(values, fmt.Sprintf("%g", b.GetUpperBound()))
+
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(base+"_bucket", metricFamily.GetHelp(), bucketNames, nil),
+					prometheus.CounterValue,
+					float64(b.GetCumulativeCount()),
+					bucketValues...,
+				)
+			}
+
+			// sum
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(base+"_sum", metricFamily.GetHelp(), names, nil),
+				prometheus.GaugeValue,
+				metric.Histogram.GetSampleSum(),
+				values...,
+			)
+
+			// count
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(base+"_count", metricFamily.GetHelp(), names, nil),
+				prometheus.CounterValue,
+				float64(metric.Histogram.GetSampleCount()),
+				values...,
 			)
 		}
 	}
@@ -319,21 +298,24 @@ func getLabelNamesAndValues(metric *dto.Metric, extraLabels []*dto.LabelPair, al
 	if extraLabels != nil {
 		labels = append(labels, extraLabels...)
 	}
+
 	names := make([]string, len(labels))
 	values := make([]string, len(labels))
+
 	for i, label := range labels {
 		names[i] = label.GetName()
 		values[i] = label.GetValue()
 	}
+
 	for k := range allLabelNames {
-		present := false
-		for _, name := range names {
-			if k == name {
-				present = true
+		found := false
+		for _, n := range names {
+			if n == k {
+				found = true
 				break
 			}
 		}
-		if !present {
+		if !found {
 			names = append(names, k)
 			values = append(values, "")
 		}
@@ -343,17 +325,15 @@ func getLabelNamesAndValues(metric *dto.Metric, extraLabels []*dto.LabelPair, al
 
 // getAllLabelNames returns the map of all label names from the metric family including any extra labels provided.
 func getAllLabelNames(metricFamily *dto.MetricFamily, extraLabels []*dto.LabelPair) map[string]struct{} {
-	allLabelNames := map[string]struct{}{}
+	all := map[string]struct{}{}
 	for _, metric := range metricFamily.Metric {
 		labels := metric.GetLabel()
 		if extraLabels != nil {
 			labels = append(labels, extraLabels...)
 		}
-		for _, label := range labels {
-			if _, ok := allLabelNames[label.GetName()]; !ok {
-				allLabelNames[label.GetName()] = struct{}{}
-			}
+		for _, l := range labels {
+			all[l.GetName()] = struct{}{}
 		}
 	}
-	return allLabelNames
+	return all
 }

--- a/pkg/collector/scraper.go
+++ b/pkg/collector/scraper.go
@@ -68,6 +68,7 @@ func NewScraper(name, metricsEndpoint string, extraMetricLabels []*dto.LabelPair
 	for _, opt := range opts {
 		opt(defOpts)
 	}
+
 	// setup http client, add auth roundtrippers
 	client := clients.NewHTTP(defOpts.timeout)
 	if defOpts.bearerTokenFile != "" {
@@ -110,6 +111,7 @@ func NewScraper(name, metricsEndpoint string, extraMetricLabels []*dto.LabelPair
 	}, nil
 }
 
+// Scraper is a remote metric scraper that scrapes HTTP endpoints
 type Scraper struct {
 	timeout            time.Duration
 	logLevel           log.Level
@@ -122,6 +124,7 @@ type Scraper struct {
 	scrapeSuccessDesc  *prometheus.Desc
 }
 
+// log emits log messages respecting the scraper's log level.
 func (s *Scraper) log(msg string, params ...interface{}) {
 	var logFunc func(msg string, params ...interface{})
 	switch s.logLevel {
@@ -130,6 +133,7 @@ func (s *Scraper) log(msg string, params ...interface{}) {
 	case log.LevelError:
 		logFunc = log.Error
 	}
+
 	logFunc(msg, params...)
 }
 
@@ -141,7 +145,11 @@ func (s *Scraper) readStream(ctx context.Context) (r io.ReadCloser, outerr error
 		if outerr == nil || r == nil {
 			return
 		}
-		_ = r.Close()
+		if err := r.Close(); err != nil {
+			// This should not happen, but if it does it'll be nice
+			// to know why we have a bunch of unclosed messages
+			s.log("failed to close stream on error: %s", err)
+		}
 	}()
 
 	resp, err := s.client.Do(s.req.WithContext(ctx))
@@ -193,7 +201,7 @@ func (s *Scraper) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) error {
+func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) (outerr error) {
 	stream, err := s.readStream(ctx)
 	if err != nil {
 		return err
@@ -211,6 +219,7 @@ func (s *Scraper) scrape(ctx context.Context, ch chan<- prometheus.Metric) error
 		}
 		convertMetricFamily(mf, ch, s.extraMetricLabels)
 	}
+
 	return nil
 }
 
@@ -221,9 +230,10 @@ func (s *Scraper) Name() string {
 
 // FilterMetric returns true if the metric should be skipped (filtered out)
 func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
-	if len(s.whitelist) == 0 {
+	if len(s.whitelist) == 0 { // if no whitelist treat all metrics as valid
 		return false
 	}
+
 	return !s.whitelist[*metricFamily.Name]
 }
 
@@ -234,59 +244,70 @@ func (s *Scraper) FilterMetric(metricFamily *dto.MetricFamily) bool {
 // see https://github.com/prometheus/node_exporter/blob/f56e8fcdf48ead56f1f149dbf1301ac028ef589b/collector/textfile.go#L63
 // for more details
 func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric, extraLabels []*dto.LabelPair) {
+	var valType prometheus.ValueType
+	var val float64
+
 	allLabelNames := getAllLabelNames(metricFamily, extraLabels)
 
 	for _, metric := range metricFamily.Metric {
 		names, values := getLabelNamesAndValues(metric, extraLabels, allLabelNames)
 
-		switch metricFamily.GetType() {
-
+		metricType := metricFamily.GetType()
+		switch metricType {
 		case dto.MetricType_COUNTER:
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(*metricFamily.Name, metricFamily.GetHelp(), names, nil),
-				prometheus.CounterValue,
-				metric.Counter.GetValue(),
-				values...,
-			)
+			valType = prometheus.CounterValue
+			val = metric.Counter.GetValue()
 
 		case dto.MetricType_GAUGE:
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(*metricFamily.Name, metricFamily.GetHelp(), names, nil),
-				prometheus.GaugeValue,
-				metric.Gauge.GetValue(),
-				values...,
-			)
+			valType = prometheus.GaugeValue
+			val = metric.Gauge.GetValue()
 
-		case dto.MetricType_HISTOGRAM:
-			base := metricFamily.GetName()
+		case dto.MetricType_UNTYPED:
+			valType = prometheus.UntypedValue
+			val = metric.Untyped.GetValue()
 
-			// buckets
-			for _, b := range metric.Histogram.Bucket {
-				bucketNames := append(names, "le")
-				bucketValues := append(values, fmt.Sprintf("%g", b.GetUpperBound()))
-
-				ch <- prometheus.MustNewConstMetric(
-					prometheus.NewDesc(base+"_bucket", metricFamily.GetHelp(), bucketNames, nil),
-					prometheus.CounterValue,
-					float64(b.GetCumulativeCount()),
-					bucketValues...,
-				)
+		case dto.MetricType_SUMMARY:
+			quantiles := map[float64]float64{}
+			for _, q := range metric.Summary.Quantile {
+				quantiles[q.GetQuantile()] = q.GetValue()
 			}
-
-			// sum
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(base+"_sum", metricFamily.GetHelp(), names, nil),
-				prometheus.GaugeValue,
-				metric.Histogram.GetSampleSum(),
-				values...,
+			ch <- prometheus.MustNewConstSummary(
+				prometheus.NewDesc(
+					*metricFamily.Name,
+					metricFamily.GetHelp(),
+					names, nil,
+				),
+				metric.Summary.GetSampleCount(),
+				metric.Summary.GetSampleSum(),
+				quantiles, values...,
 			)
-
-			// count
+		case dto.MetricType_HISTOGRAM:
+			buckets := map[float64]uint64{}
+			for _, b := range metric.Histogram.Bucket {
+				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
+			}
+			ch <- prometheus.MustNewConstHistogram(
+				prometheus.NewDesc(
+					*metricFamily.Name,
+					metricFamily.GetHelp(),
+					names, nil,
+				),
+				metric.Histogram.GetSampleCount(),
+				metric.Histogram.GetSampleSum(),
+				buckets, values...,
+			)
+		default:
+			log.Error("unknown metric type %q", metricType.String())
+			continue
+		}
+		if metricType == dto.MetricType_GAUGE || metricType == dto.MetricType_COUNTER || metricType == dto.MetricType_UNTYPED {
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(base+"_count", metricFamily.GetHelp(), names, nil),
-				prometheus.CounterValue,
-				float64(metric.Histogram.GetSampleCount()),
-				values...,
+				prometheus.NewDesc(
+					*metricFamily.Name,
+					metricFamily.GetHelp(),
+					names, nil,
+				),
+				valType, val, values...,
 			)
 		}
 	}
@@ -298,24 +319,21 @@ func getLabelNamesAndValues(metric *dto.Metric, extraLabels []*dto.LabelPair, al
 	if extraLabels != nil {
 		labels = append(labels, extraLabels...)
 	}
-
 	names := make([]string, len(labels))
 	values := make([]string, len(labels))
-
 	for i, label := range labels {
 		names[i] = label.GetName()
 		values[i] = label.GetValue()
 	}
-
 	for k := range allLabelNames {
-		found := false
-		for _, n := range names {
-			if n == k {
-				found = true
+		present := false
+		for _, name := range names {
+			if k == name {
+				present = true
 				break
 			}
 		}
-		if !found {
+		if !present {
 			names = append(names, k)
 			values = append(values, "")
 		}
@@ -325,15 +343,17 @@ func getLabelNamesAndValues(metric *dto.Metric, extraLabels []*dto.LabelPair, al
 
 // getAllLabelNames returns the map of all label names from the metric family including any extra labels provided.
 func getAllLabelNames(metricFamily *dto.MetricFamily, extraLabels []*dto.LabelPair) map[string]struct{} {
-	all := map[string]struct{}{}
+	allLabelNames := map[string]struct{}{}
 	for _, metric := range metricFamily.Metric {
 		labels := metric.GetLabel()
 		if extraLabels != nil {
 			labels = append(labels, extraLabels...)
 		}
-		for _, l := range labels {
-			all[l.GetName()] = struct{}{}
+		for _, label := range labels {
+			if _, ok := allLabelNames[label.GetName()]; !ok {
+				allLabelNames[label.GetName()] = struct{}{}
+			}
 		}
 	}
-	return all
+	return allLabelNames
 }


### PR DESCRIPTION
This change adds support in do-agent to properly collect and aggregate Dedicated Inference (DI) metrics for Insights.

this PR:
- Adds DI metrics to the whitelist so they are accepted by do-agent
- Defines aggregation rules for DI metrics to control label cardinality
- Preserves Prometheus histogram semantics by keeping le labels for _bucket metrics
- Drops high-cardinality labels like job, pod, and OTEL scope labels where appropriate
- Ensures _bucket, _sum, and _count metrics remain consistent and query-safe
- The goal is to make DI metrics safe, efficient, and compatible with Insights ingestion.

**Testing performed**

Ran do-agent with a local DI Prometheus-style metrics endpoint:

go run ./cmd/do-agent \
  --di-metrics-address http://127.0.0.1:9109/metrics \
  --stdout-only

- Verified that DI metrics are:
- Successfully scraped
- Present in agent output
- Correctly aggregated
- Confirmed that:
- Histogram metrics (*_bucket, *_sum, *_count) are emitted correctly
- le label is preserved for bucket metrics
- High-cardinality labels (job, pod) are removed from aggregated DI metrics
- Manually inspected output to ensure no unintended label or metric drops
- No integration or production environment changes were required for this PR.