### PR TITLE
do-agent: add DI metrics whitelist

### DIFF
--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -198,3 +198,42 @@ var gpuAggregationSpec = map[string][]string{
 	"amd_gpu_gfx_activity":                                amdAggregatedLabels,
 	"amd_gpu_prof_sm_active":                              amdAggregatedLabels,
 }
+
+// DI metrics: drop high-cardinality labels we don't want to keep.
+// NOTE: do NOT include "le" because bucket-style series need it.
+var diLabelsToDrop = []string{
+	"container",
+	"job",
+	"otel_scope_name",
+	"otel_scope_schema_url",
+	"otel_scope_version",
+}
+
+// diAggregationSpec lists DI metric names and which labels should be DROPPED.
+// Anything NOT in this list will keep labels as-is.
+var diAggregationSpec = map[string][]string{
+	// DI GPU metrics
+	"gradient_infra_di_gpu_junction_temperature":       diLabelsToDrop,
+	"gradient_infra_di_gpu_total_vram":                 diLabelsToDrop,
+	"gradient_infra_di_gpu_used_vram":                  diLabelsToDrop,
+	"gradient_infra_di_gpu_free_vram":                  diLabelsToDrop,
+	"gradient_infra_di_gpu_occupancy_percent":          diLabelsToDrop,
+	"gradient_infra_di_gpu_tensor_utilization_percent": diLabelsToDrop,
+	"gradient_infra_di_gpu_memory_temperature":         diLabelsToDrop,
+
+	// Objective counters
+	"gradient_infra_di_inference_objective_request_error_total": diLabelsToDrop,
+	"gradient_infra_di_inference_objective_request_total":       diLabelsToDrop,
+
+	// vLLM non-bucket metrics
+	"gradient_infra_di_vllm:generation_tokens_total": diLabelsToDrop,
+	"gradient_infra_di_vllm:num_requests_running":    diLabelsToDrop,
+	"gradient_infra_di_vllm:num_requests_waiting":    diLabelsToDrop,
+	"gradient_infra_di_vllm:kv_cache_usage_perc":     diLabelsToDrop,
+
+	// vLLM bucket-style series
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           diLabelsToDrop,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           diLabelsToDrop,
+	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": diLabelsToDrop,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           diLabelsToDrop,
+}

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -46,6 +46,7 @@ var (
 		defaultMaxBatchSize    int
 		defaultMaxMetricLength int
 		promAddr               string
+		diMetricsPath          string
 		gpuMetricsPath         string
 		topK                   int
 		scrapeTimeout          time.Duration
@@ -126,6 +127,9 @@ func init() {
 
 	kingpin.Flag("gpu-metrics-path", "enable GPU metrics collection from a prometheus endpoint (e.g., AMD device-metrics-exporter)").
 		StringVar(&config.gpuMetricsPath)
+
+	kingpin.Flag("di-metrics-path", "enable Dedicated Inference (DI) metrics collection from a prometheus endpoint").
+		StringVar(&config.diMetricsPath)
 
 	kingpin.Flag("web.listen", "enable a local endpoint for scrapeable prometheus metrics as well").
 		Default("false").
@@ -258,7 +262,11 @@ func initAggregatorSpecs() map[string][]string {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
 	}
-
+	if config.diMetricsPath != "" {
+		for k, v := range diAggregationSpec {
+			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
+		}
+	}
 	return aggregateSpecs
 }
 
@@ -330,6 +338,15 @@ func initCollectors() []prometheus.Collector {
 			log.Error("Failed to initialize generic metrics collector: %+v", err)
 		} else {
 			cols = append(cols, k)
+		}
+	}
+
+	if config.diMetricsPath != "" {
+		di, err := collector.NewScraper("di", config.diMetricsPath, nil, diWhitelist, collector.WithTimeout(config.scrapeTimeout))
+		if err != nil {
+			log.Error("Failed to initialize DI metrics collector: %+v", err)
+		} else {
+			cols = append(cols, di)
 		}
 	}
 

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -249,3 +249,28 @@ var gpuWhitelist = map[string]bool{
 	"amd_gpu_gfx_activity":                                true,
 	"amd_gpu_prof_sm_active":                              true,
 }
+var diWhitelist = map[string]bool{
+	// DI GPU metrics
+	"gradient_infra_di_gpu_junction_temperature":       true,
+	"gradient_infra_di_gpu_total_vram":                 true,
+	"gradient_infra_di_gpu_used_vram":                  true,
+	"gradient_infra_di_gpu_free_vram":                  true,
+	"gradient_infra_di_gpu_occupancy_percent":          true,
+	"gradient_infra_di_gpu_tensor_utilization_percent": true,
+	"gradient_infra_di_gpu_memory_temperature":         true,
+
+	// Objective counters
+	"gradient_infra_di_inference_objective_request_error_total": true,
+	"gradient_infra_di_inference_objective_request_total":       true,
+
+	// vLLM
+
+	"gradient_infra_di_vllm:generation_tokens_total":                      true,
+	"gradient_infra_di_vllm:num_requests_running":                         true,
+	"gradient_infra_di_vllm:num_requests_waiting":                         true,
+	"gradient_infra_di_vllm:kv_cache_usage_perc":                          true,
+	"gradient_infra_di_vllm:e2e_request_latency_seconds_bucket":           true,
+	"gradient_infra_di_vllm:inter_token_latency_seconds_bucket":           true,
+	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": true,
+	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           true,
+}


### PR DESCRIPTION
This PR adds and syncs Dedicated Inference (DI) metrics support in do-agent.

Changes included:
- Added DI metrics whitelist for GPU, objective counters, and vLLM metrics
- Added --di-metrics-path flag to enable DI metrics scraping
- Added aggregation rules to drop high-cardinality labels while preserving histogram buckets (le)
- Consolidated earlier work into a single clean PR (earlier PRs closed)

Validation:
- Verified DI vLLM *_bucket metrics are scraped correctly
- Confirmed histogram labels (le) are preserved
- Confirmed high-cardinality labels are dropped via aggregation as expected
