### PR TITLE
do-agent: allow additonal AMD metrics

### DIFF
--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -177,7 +177,10 @@ var gpuAggregationSpec = map[string][]string{
 	// PCIe bandwidth
 	"amd_pcie_bandwidth": amdAggregatedLabels,
 
+	"amd_gpu_ecc_correct_total":                           amdAggregatedLabels,
 	"amd_gpu_ecc_uncorrect_total":                         amdAggregatedLabels,
+	"amd_pcie_nack_sent_count":                            amdAggregatedLabels,
+	"amd_pcie_nack_received_count":                        amdAggregatedLabels,
 	"amd_pcie_replay_count":                               amdAggregatedLabels,
 	"amd_pcie_recovery_count":                             amdAggregatedLabels,
 	"amd_pcie_replay_rollover_count":                      amdAggregatedLabels,


### PR DESCRIPTION
As part of, IN-6633, we require additional metrics to be available via do-agent. Most were already being scraped, but a handful were not.