### PR TITLE
do-agent: add SI metrics support with aggregation and whitelist

### DIFF
--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -237,3 +237,21 @@ var diAggregationSpec = map[string][]string{
 	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": diLabelsToDrop,
 	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           diLabelsToDrop,
 }
+
+// SI metrics: drop high-cardinality labels we don't want to keep.
+var siLabelsToDrop = []string{
+	"container",
+	"job",
+	"otel_scope_name",
+	"otel_scope_schema_url",
+	"otel_scope_version",
+	"resource_uuid",
+}
+
+var siAggregationSpec = map[string][]string{
+	"gen_ai_otel_inference_proxy_http_requests_total":  siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_token_throughput":     siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_rate_limit_exceeded":  siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_cache_hit":            siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_cache_miss":           siLabelsToDrop,
+}

--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -249,9 +249,13 @@ var siLabelsToDrop = []string{
 }
 
 var siAggregationSpec = map[string][]string{
-	"gen_ai_otel_inference_proxy_http_requests_total": siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_token_throughput":    siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_rate_limit_exceeded": siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_cache_hit":           siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_cache_miss":          siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_http_requests_total":                   siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_http_request_duration_seconds":         siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_token_throughput":                      siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_rate_limit_exceeded":                   siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_cache_hit":                             siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_cache_miss":                            siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_inference_client_ttft_duration":        siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_inference_client_itl_duration_seconds": siLabelsToDrop,
+	"gen_ai_platform_inference_proxy_inference_client_requests_total":       siLabelsToDrop,
 }

--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -249,9 +249,9 @@ var siLabelsToDrop = []string{
 }
 
 var siAggregationSpec = map[string][]string{
-	"gen_ai_otel_inference_proxy_http_requests_total":  siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_token_throughput":     siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_rate_limit_exceeded":  siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_cache_hit":            siLabelsToDrop,
-	"gen_ai_otel_inference_proxy_cache_miss":           siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_http_requests_total": siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_token_throughput":    siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_rate_limit_exceeded": siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_cache_hit":           siLabelsToDrop,
+	"gen_ai_otel_inference_proxy_cache_miss":          siLabelsToDrop,
 }

--- a/cmd/do-agent/config.go
+++ b/cmd/do-agent/config.go
@@ -47,6 +47,7 @@ var (
 		defaultMaxMetricLength int
 		promAddr               string
 		diMetricsPath          string
+		siMetricsPath          string
 		gpuMetricsPath         string
 		topK                   int
 		scrapeTimeout          time.Duration
@@ -130,6 +131,9 @@ func init() {
 
 	kingpin.Flag("di-metrics-path", "enable Dedicated Inference (DI) metrics collection from a prometheus endpoint").
 		StringVar(&config.diMetricsPath)
+
+	kingpin.Flag("si-metrics-path", "enable Serverless Inference (SI) metrics collection from a prometheus endpoint").
+		StringVar(&config.siMetricsPath)
 
 	kingpin.Flag("web.listen", "enable a local endpoint for scrapeable prometheus metrics as well").
 		Default("false").
@@ -267,6 +271,11 @@ func initAggregatorSpecs() map[string][]string {
 			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
 		}
 	}
+	if config.siMetricsPath != "" {
+		for k, v := range siAggregationSpec {
+			aggregateSpecs[k] = append(aggregateSpecs[k], v...)
+		}
+	}
 	return aggregateSpecs
 }
 
@@ -347,6 +356,15 @@ func initCollectors() []prometheus.Collector {
 			log.Error("Failed to initialize DI metrics collector: %+v", err)
 		} else {
 			cols = append(cols, di)
+		}
+	}
+
+	if config.siMetricsPath != "" {
+		si, err := collector.NewScraper("si", config.siMetricsPath, nil, siWhitelist, collector.WithTimeout(config.scrapeTimeout))
+		if err != nil {
+			log.Error("Failed to initialize SI metrics collector: %+v", err)
+		} else {
+			cols = append(cols, si)
 		}
 	}
 

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -276,9 +276,13 @@ var diWhitelist = map[string]bool{
 }
 
 var siWhitelist = map[string]bool{
-	"gen_ai_otel_inference_proxy_http_requests_total": true,
-	"gen_ai_otel_inference_proxy_token_throughput":    true,
-	"gen_ai_otel_inference_proxy_rate_limit_exceeded": true,
-	"gen_ai_otel_inference_proxy_cache_hit":           true,
-	"gen_ai_otel_inference_proxy_cache_miss":          true,
+	"gen_ai_platform_inference_proxy_http_requests_total":                   true,
+	"gen_ai_platform_inference_proxy_http_request_duration_seconds":         true,
+	"gen_ai_platform_inference_proxy_token_throughput":                      true,
+	"gen_ai_platform_inference_proxy_rate_limit_exceeded":                   true,
+	"gen_ai_platform_inference_proxy_cache_hit":                             true,
+	"gen_ai_platform_inference_proxy_cache_miss":                            true,
+	"gen_ai_platform_inference_proxy_inference_client_ttft_duration":        true,
+	"gen_ai_platform_inference_proxy_inference_client_itl_duration_seconds": true,
+	"gen_ai_platform_inference_proxy_inference_client_requests_total":       true,
 }

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -276,9 +276,9 @@ var diWhitelist = map[string]bool{
 }
 
 var siWhitelist = map[string]bool{
-	"gen_ai_otel_inference_proxy_http_requests_total":  true,
-	"gen_ai_otel_inference_proxy_token_throughput":     true,
-	"gen_ai_otel_inference_proxy_rate_limit_exceeded":  true,
-	"gen_ai_otel_inference_proxy_cache_hit":            true,
-	"gen_ai_otel_inference_proxy_cache_miss":           true,
+	"gen_ai_otel_inference_proxy_http_requests_total": true,
+	"gen_ai_otel_inference_proxy_token_throughput":    true,
+	"gen_ai_otel_inference_proxy_rate_limit_exceeded": true,
+	"gen_ai_otel_inference_proxy_cache_hit":           true,
+	"gen_ai_otel_inference_proxy_cache_miss":          true,
 }

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -274,3 +274,11 @@ var diWhitelist = map[string]bool{
 	"gradient_infra_di_vllm:request_time_per_output_token_seconds_bucket": true,
 	"gradient_infra_di_vllm:time_to_first_token_seconds_bucket":           true,
 }
+
+var siWhitelist = map[string]bool{
+	"gen_ai_otel_inference_proxy_http_requests_total":  true,
+	"gen_ai_otel_inference_proxy_token_throughput":     true,
+	"gen_ai_otel_inference_proxy_rate_limit_exceeded":  true,
+	"gen_ai_otel_inference_proxy_cache_hit":            true,
+	"gen_ai_otel_inference_proxy_cache_miss":           true,
+}


### PR DESCRIPTION
- Introduced SI metrics path configuration for Serverless Inference (SI) metrics collection.
- Added SI metrics aggregation specifications to drop high-cardinality labels.
- Implemented a whitelist for SI metrics to control which metrics are collected.

Reference -> https://github.com/digitalocean/do-agent/pull/348