### PR TITLE
CON-13656 Rename amd_pcie_nac_received_count to amd_pcie_nack_received_count

### DIFF
--- a/cmd/do-agent/aggregation.go
+++ b/cmd/do-agent/aggregation.go
@@ -196,7 +196,7 @@ var gpuAggregationSpec = map[string][]string{
 	"amd_pcie_replay_rollover_count":                         amdAggregatedLabels,
 	"amd_pcie_max_speed":                                     amdAggregatedLabels,
 	"amd_pcie_speed":                                         amdAggregatedLabels,
-	"amd_pcie_nac_received_count":                            amdAggregatedLabels,
+	"amd_pcie_nack_received_count":                           amdAggregatedLabels,
 	"amd_pcie_nack_sent_count":                               amdAggregatedLabels,
 	"amd_gpu_prof_cpf_cpf_stat_stall":                        amdAggregatedLabels,
 	"amd_gpu_clock":                                          amdAggregatedLabels,

--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -247,7 +247,7 @@ var gpuWhitelist = map[string]bool{
 	"amd_pcie_replay_rollover_count":                         true,
 	"amd_pcie_max_speed":                                     true,
 	"amd_pcie_speed":                                         true,
-	"amd_pcie_nac_received_count":                            true,
+	"amd_pcie_nack_received_count":                           true,
 	"amd_pcie_nack_sent_count":                               true,
 	"amd_gpu_prof_cpf_cpf_stat_stall":                        true,
 	"amd_gpu_clock":                                          true,


### PR DESCRIPTION
Rename metric from `amd_pcie_nac_received_count` to `amd_pcie_nack_received_count`

I did a test on DOKS amd cluster and got this from the device metrics exporter. 

```shell
> curl http://0.0.0.0:5000/metrics | grep -i PCIE_NACK_RECEIVED_COUNT
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  151k    0  151k    0     0  12.3M      0 --:--:-- --:--:-- --:--:-- 13.4M
# HELP amd_pcie_nack_received_count PCIe NAK received accumulated count
# TYPE amd_pcie_nack_received_count gauge
amd_pcie_nack_received_count{card_model="",card_series="Aqua Vanjaram [Instinct MI300X VF]",card_vendor="Advanced Micro Devices, Inc. [AMD/ATI]",cluster_name="",container="",deployment_mode="vm_vf",driver_version="6.14.14",gpu_compute_partition_type="spx",gpu_id="0",gpu_memory_partition_type="nps1",gpu_partition_id="0",gpu_uuid="b3ff74b5-0000-1000-80e8-d2ece4852a7c",hostname="gpu-drmxg",job_id="",job_partition="",job_user="",kfd_process_id="4450",namespace="",pod="",serial_number="",vbios_version="00159017"} 0
```

Empty response for 
```shell
[root@gpu-drmxg ~]# curl http://0.0.0.0:5000/metrics | grep -i PCIE_NAC_RECEIVED_COUNT
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  151k    0  151k    0     0  14.8M      0 --:--:-- --:--:-- --:--:-- 14.8M
```
