### PR TITLE
[DBAAS-8750] | Whitelist mysql_up in dbaas metrics for Advanced MySQL data-plane alerting

### DIFF
--- a/cmd/do-agent/whitelist.go
+++ b/cmd/do-agent/whitelist.go
@@ -70,6 +70,8 @@ var dbaasWhitelist = map[string]bool{
 
 	// Advanced MySQL / Percona (mysqld_exporter native names; no relabeling)
 	//
+	// MySQL Engine & Database Activity
+	"mysql_up": true,
 	// MySQL Global Status (Gauges & Counters)
 	"mysql_global_status_uptime":                  true,
 	"mysql_global_status_queries":                 true,


### PR DESCRIPTION
## Summary
Adds `mysql_up` to `dbaasWhitelist` so the mysqld_exporter up gauge is forwarded when do-agent scrapes `--dbaas-metrics-path`.

## Why
`mysql_up` is the MySQL equivalent of the already-whitelisted `pg_up` (`1` = MySQL reachable, `0` = not). The exporter emits it, but do-agent currently drops it before metrics reach Insights/metis.

Needed for Advanced MySQL data-plane paging alerts (same pattern as Advanced PG `pg_up`).

## Test plan
- [x] `go test ./cmd/do-agent/... ./pkg/collector/...`