### PR TITLE
Fix filesystem collector filters: overlay fstype and containerd mount paths

### DIFF
--- a/cmd/do-agent/config_filesystem.go
+++ b/cmd/do-agent/config_filesystem.go
@@ -8,14 +8,14 @@ import (
 const (
 	ignoredMountPointFlag = "--collector.filesystem.ignored-mount-points"
 	ignoredFSTypesFlag    = "--collector.filesystem.ignored-fs-types"
-	ignoredMountPoints    = `^/(rootfs/)?(boot|sys|proc|dev|host|etc|tmp|usr/(home|ports|src)|var/(audit|crash|log|mail|tmp)|var/(lib|run)/docker/[^$]+|run/docker/[^$]+)($$|/)`
+	ignoredMountPoints    = `^/(rootfs/)?(boot|sys|proc|dev|host|etc|tmp|usr/(home|ports|src)|var/(audit|crash|log|mail|tmp)|var/(lib|run)/(docker|containerd)/[^$]+|run/(docker|containerd)/[^$]+)($$|/)`
 )
 
 var (
 	ignoredFSTypes = strings.Join([]string{
 		"aufs", "autofs", "binfmt_misc", "cd9660", "cifs", "cgroup", "debugfs",
 		"devpts", "devtmpfs", "ecryptfs", "efivarfs", "fuse",
-		"hugetlbfs", "mqueue", "nfs", "overlayfs", "proc", "pstore",
+		"hugetlbfs", "mqueue", "nfs", "overlay", "proc", "pstore",
 		"rpc_pipefs", "securityfs", "smb", "sysfs", "tmpfs", "tracefs",
 		"squashfs", "nsfs",
 	}, `|`)

--- a/cmd/do-agent/config_filesystem_test.go
+++ b/cmd/do-agent/config_filesystem_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,4 +21,55 @@ func TestRegisterFilesystemFlagsRegistersMountPointFlag(t *testing.T) {
 	registerFilesystemFlags()
 	assert.NotEmpty(t, additionalParams)
 	assert.Contains(t, additionalParams, ignoredMountPoints)
+}
+
+func TestIgnoredMountPointsMatching(t *testing.T) {
+	re := regexp.MustCompile(ignoredMountPoints)
+
+	tests := []struct {
+		mountPoint string
+		ignored    bool
+	}{
+		{"/", false},
+		{"/scratch", false},
+		{"/mnt/doscratch", false},
+		{"/boot", true},
+		{"/proc", true},
+		{"/sys", true},
+		{"/dev", true},
+		{"/host", true},
+		{"/var/lib/docker/overlay2/abc123", true},
+		{"/run/docker/netns/default", true},
+		{"/run/containerd/io.containerd.runtime.v2.task/k8s.io/abc123/rootfs", true},
+		{"/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/42/fs", true},
+	}
+
+	for _, tt := range tests {
+		got := re.MatchString(tt.mountPoint)
+		assert.Equal(t, tt.ignored, got, "mount point %q: got ignored=%t, want ignored=%t", tt.mountPoint, got, tt.ignored)
+	}
+}
+
+func TestIgnoredFSTypesMatching(t *testing.T) {
+	re := regexp.MustCompile(ignoredFSTypes)
+
+	tests := []struct {
+		fsType  string
+		ignored bool
+	}{
+		{"ext4", false},
+		{"xfs", false},
+		{"btrfs", false},
+		{"overlay", true},
+		{"overlayfs", true},
+		{"tmpfs", true},
+		{"sysfs", true},
+		{"proc", true},
+		{"nsfs", true},
+	}
+
+	for _, tt := range tests {
+		got := re.MatchString(tt.fsType)
+		assert.Equal(t, tt.ignored, got, "fs type %q: got ignored=%t, want ignored=%t", tt.fsType, got, tt.ignored)
+	}
 }


### PR DESCRIPTION
## Summary

The filesystem collector's exclude filters have gaps that let container runtime
mounts through. This inflates series count on and added noise to the Droplet Insights Disk Usage chart.

- `overlayfs` doesn't show up in mount tables, but `overlay` does, and was seen in Insights disk usage charts. Changing this to `overlay` will also match `overlayfs`.

- `containerd` added alongside docker in `ignoredMountPoints` as precaution to catch any containerd mounts whose type isn't `overlay`.

- Verified that the Droplet Insights disk chart groups no longer shows extraneous mounts by deploying a prerelease image on a live Kubernetes node and confirmed the excess mounts are gone from Insights chart on the Droplet.
